### PR TITLE
Party preserving algorithm

### DIFF
--- a/lib/balance_lib.ex
+++ b/lib/balance_lib.ex
@@ -1,69 +1,18 @@
 defmodule Teiserver.Battle.BalanceLib do
   @moduledoc """
   A set of functions related to balance, if you are looking to see how balance is implemented this is the place. Ratings are calculated via Teiserver.Game.MatchRatingLib and are used here. Please note ratings and balance are two very different things and complaints about imbalanced games need to be correct in addressing balance vs ratings.
-
-  Currently the algorithm is "Loser picks". The Algorithm at a high level is:
-  1: Dealing with parties
-    - Go through all groups of 2 or more members and combine their ratings to create one rating for the group
-    - If the group can be paired against a group of equal strength or if any of the remaining solo players can be combined to form a group of sufficiently equal strength, the original group remains intact
-    - Any groups that cannot be matched against a suitable group will be broken into solo players and balanced as such
-
-  2: Placing paired groups
-    - Each pairing of groups are iterated through and assigned to opposite teams
-    - The team with the lowest combined rating picks first and selects the highest rated group
-
-  3: Solo players
-    - As long as there are players left to place
-    - Whichever team with the lowest combined rating and is not full picks next
-    - Said team always picks the highest rated group available
   """
-  alias Central.Config
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Account
   alias Teiserver.Game.MatchRatingLib
-  import Central.Helpers.NumberHelper, only: [int_parse: 1, round: 2]
+  alias Teiserver.Battle.LoserPicksAlgorithm
+  alias Teiserver.Battle.PartyPreserverAlgorithm
+  import Central.Helpers.NumberHelper, only: [int_parse: 1]
+  import Teiserver.Battle.BalanceUtil
 
-  # These are default values and can be overridden as part of the call to create_balance()
+  @type player_group :: BalanceUtils.player_group
+  @type rating_value :: BalanceUtils.rating_value
 
-  # Upper boundary is how far above the group value the members can be, lower is how far below it
-  # these values are in general used for group pairing where we look at making temporary groups on
-  # each team to make the battle fair
-  @rating_lower_boundary 3
-  @rating_upper_boundary 5
-
-  @mean_diff_max 5
-  @stddev_diff_max 3
-
-  # Fuzz multiplier is used by the BalanceServer to prevent two games being completely identical
-  # teams. It is defaulted here as the server uses this library to get defaults
-  @fuzz_multiplier 0.5
-
-  # When set to true, if there are any teams with 0 points (first pick) it randomises
-  # which one will get to pick first
-  @shuffle_first_pick true
-
-  @spec defaults() :: map()
-  def defaults() do
-    %{
-      max_deviation: Config.get_site_config_cache("teiserver.Max deviation"),
-      rating_lower_boundary: @rating_lower_boundary,
-      rating_upper_boundary: @rating_upper_boundary,
-      mean_diff_max: @mean_diff_max,
-      stddev_diff_max: @stddev_diff_max,
-      fuzz_multiplier: @fuzz_multiplier,
-      shuffle_first_pick: @shuffle_first_pick
-    }
-  end
-
-  @type rating_value() :: float()
-  @type player_group() :: %{T.userid() => rating_value()}
-  @type expanded_group() :: %{
-          members: [T.userid()],
-          ratings: [rating_value()],
-          group_rating: rating_value(),
-          count: non_neg_integer()
-        }
-  @type expanded_group_or_pair() :: expanded_group() | {expanded_group(), expanded_group()}
 
   @doc """
   groups is a list of maps of %{userid => rating_value}
@@ -106,42 +55,13 @@ defmodule Teiserver.Battle.BalanceLib do
         }
       end)
 
-    # Now we have a list of groups, we need to work out which groups we're going to keep
-    # we want to create partner groups but we're only going to do this in a 2 team game
-    # because in a team ffa it'll be very problematic
-    solo_players =
-      expanded_groups
-      |> Enum.filter(fn %{count: count} -> count == 1 end)
-
-    groups =
-      expanded_groups
-      |> Enum.filter(fn %{count: count} -> count > 1 end)
-
-    {group_pairs, solo_players, group_logs} =
-      matchup_groups(groups, solo_players, opts ++ [team_count: team_count])
-
-    # We now need to sort the solo players by rating
-    solo_players =
-      solo_players
-      |> Enum.sort_by(fn %{group_rating: rating} -> rating end, &>=/2)
-
-    teams =
-      Range.new(1, team_count)
-      |> Map.new(fn i ->
-        {i, []}
-      end)
-
-    {reversed_team_groups, logs} =
+    {team_groups, logs} =
       case opts[:algorithm] || :loser_picks do
+        :party_preserver ->
+          PartyPreserverAlgorithm.party_preserver(expanded_groups, team_count, opts)
         :loser_picks ->
-          loser_picks(group_pairs ++ solo_players, teams, opts)
+          LoserPicksAlgorithm.loser_picks(expanded_groups, team_count, opts)
       end
-
-    team_groups =
-      reversed_team_groups
-      |> Map.new(fn {team_id, groups} ->
-        {team_id, Enum.reverse(groups)}
-      end)
 
     team_players =
       team_groups
@@ -159,199 +79,10 @@ defmodule Teiserver.Battle.BalanceLib do
     %{
       team_groups: team_groups,
       team_players: team_players,
-      logs: group_logs ++ logs,
+      logs: logs,
       time_taken: time_taken
     }
     |> calculate_balance_stats
-  end
-
-  # We return a list of groups, a list of solo players and logs generated in the process
-  # the purpose of this function is to go through the groups, work out which ones we can keep as
-  # groups and with the ones we can't, break them up and add them back into the pool of solo
-  # players for other groups
-  @spec matchup_groups([expanded_group()], [expanded_group()], list()) ::
-          {[expanded_group()], [expanded_group()], [String.t()]}
-  defp matchup_groups([], solo_players, _opts), do: {[], solo_players, []}
-
-  defp matchup_groups(groups, solo_players, opts) do
-    # First we want to re-sort these groups, we want to have the ones with the highest standard
-    # deviation looked at first, they are the least likely to be able to be matched but most likely to
-    # help match others
-    groups =
-      groups
-      |> Enum.sort_by(
-        fn group ->
-          {group.count, Statistics.stdev(group.ratings)}
-        end,
-        &<=/2
-      )
-
-    do_matchup_groups(groups ++ solo_players, [], [], opts)
-  end
-
-  # First argument is a list of groups (size 1 included) that need to be paired
-  # the second argument is a list of the logs built up by the function
-  # thirdly is a list of already paired up groups (so can't be paired up further)
-  # fourth is the opts list
-  # the function returns a tuple of
-  # 1: paired groups
-  # 2: non-paired groups
-  # 3: logs
-  @spec do_matchup_groups([expanded_group()], [String.t()], [expanded_group()], list()) ::
-          {[expanded_group()], [expanded_group()], [String.t()]}
-  # No groups, no logs
-  defp do_matchup_groups([], [], previous_paired_groups, _opts) do
-    {previous_paired_groups, [], []}
-  end
-
-  # No remaining groups but have some logs
-  defp do_matchup_groups([], logs, previous_paired_groups, _opts) do
-    {previous_paired_groups, [], logs ++ ["End of pairing"]}
-  end
-
-  # This matches when the next group is a size 1, we no longer need to pair up
-  defp do_matchup_groups(
-         [%{count: 1} | _] = remaining_players,
-         logs,
-         previous_paired_groups,
-         _opts
-       ) do
-    {previous_paired_groups, remaining_players, logs ++ ["End of pairing"]}
-  end
-
-  # Main function clause
-  defp do_matchup_groups([group | remaining_groups], logs, previous_paired_groups, opts) do
-    group_mean = Enum.sum(group.ratings) / Enum.count(group.ratings)
-    group_stddev = Statistics.stdev(group.ratings)
-
-    {_remaining_solo, found_groups} =
-      1..(opts[:team_count] - 1)
-      |> Enum.reduce({remaining_groups, []}, fn _, {groups_to_search, results} ->
-        result = find_comparable_group(group, groups_to_search, opts)
-
-        new_groups_to_search =
-          case result do
-            :no_possible_combinations ->
-              []
-
-            :no_possible_players ->
-              []
-
-            %{members: found_members} ->
-              groups_to_search
-              |> Enum.reject(fn %{members: members} ->
-                members
-                |> Enum.any?(fn userid -> Enum.member?(found_members, userid) end)
-              end)
-          end
-
-        {new_groups_to_search, [result | results]}
-      end)
-
-    case hd(found_groups) do
-      :no_possible_combinations ->
-        extra_solos =
-          Enum.zip(group.members, group.ratings)
-          |> Enum.map(fn {userid, rating} ->
-            %{
-              count: 1,
-              group_rating: rating,
-              members: [userid],
-              ratings: [rating]
-            }
-          end)
-
-        names =
-          group.members
-          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
-
-        pairing_logs = [
-          "Unable to find a combination match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
-        ]
-
-        do_matchup_groups(
-          remaining_groups ++ extra_solos,
-          logs ++ pairing_logs,
-          previous_paired_groups,
-          opts
-        )
-
-      :no_possible_players ->
-        extra_solos =
-          Enum.zip(group.members, group.ratings)
-          |> Enum.map(fn {userid, rating} ->
-            %{
-              count: 1,
-              group_rating: rating,
-              members: [userid],
-              ratings: [rating]
-            }
-          end)
-
-        names =
-          group.members
-          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
-
-        pairing_logs = [
-          "Unable to find a player match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
-        ]
-
-        do_matchup_groups(
-          remaining_groups ++ extra_solos,
-          logs ++ pairing_logs,
-          previous_paired_groups,
-          opts
-        )
-
-      _ ->
-        # Calculate remaining solo players
-        combined_member_ids =
-          found_groups
-          |> Enum.map(fn g -> g.members end)
-          |> List.flatten()
-
-        remaining_groups =
-          remaining_groups
-          |> Enum.reject(fn %{members: members} ->
-            members
-            |> Enum.any?(fn userid -> Enum.member?(combined_member_ids, userid) end)
-          end)
-
-        # Generate log lines, using fgroup so it doesn't clash with group used
-        # earlier
-        grouped_logs =
-          [group | found_groups]
-          |> Enum.map(fn fgroup ->
-            fgroup_name =
-              fgroup.members
-              |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
-
-            fgroup_mean = Enum.sum(fgroup.ratings) / Enum.count(fgroup.ratings)
-            fgroup_stddev = Statistics.stdev(fgroup.ratings)
-
-            [
-              "> Grouped: #{fgroup_name}",
-              "--- Rating sum: #{fgroup.group_rating |> round(2)}",
-              "--- Rating Mean: #{fgroup_mean |> round(2)}",
-              "--- Rating Stddev: #{fgroup_stddev |> round(2)}"
-            ]
-          end)
-          |> List.flatten()
-
-        logs = ["Group matching" | logs]
-
-        # Now order the groups by rating so we can pick in the right order
-        found_groups =
-          [group | found_groups]
-          |> Enum.sort_by(fn fg -> fg.group_rating end, &>=/2)
-
-        do_matchup_groups(
-          remaining_groups,
-          logs ++ grouped_logs,
-          [found_groups | previous_paired_groups],
-          opts
-        )
-    end
   end
 
   @doc """
@@ -505,118 +236,6 @@ defmodule Teiserver.Battle.BalanceLib do
   end
 
   @doc """
-  Each round the team with the lowest score picks, if a team has the maximum number of players
-  they are not allowed to continue picking.
-
-  groups is a list of tuples: {members, rating, member_count}
-  """
-  @spec loser_picks([expanded_group_or_pair()], map(), list()) :: {map(), list()}
-  def loser_picks(groups, teams, opts) do
-    total_members =
-      groups
-      |> Enum.map(fn
-        {%{count: count1}, %{count: count2}} ->
-          count1 + count2
-
-        %{count: count} ->
-          count
-
-        group_list ->
-          group_list
-          |> Enum.map(fn g -> g.count end)
-          |> Enum.sum()
-      end)
-      |> Enum.sum()
-
-    max_teamsize = (total_members / Enum.count(teams)) |> :math.ceil() |> round()
-    do_loser_picks(groups, teams, max_teamsize, [], opts)
-  end
-
-  @spec do_loser_picks([expanded_group()], map(), non_neg_integer(), list(), list()) ::
-          {map(), list()}
-  defp do_loser_picks([], teams, _, logs, _opts), do: {teams, logs}
-
-  defp do_loser_picks([picked | remaining_groups], teams, max_teamsize, logs, opts) do
-    team_skills =
-      teams
-      |> Enum.reject(fn {_team_number, member_groups} ->
-        size = sum_group_membership_size(member_groups)
-        size >= max_teamsize
-      end)
-      |> Enum.map(fn {team_number, member_groups} ->
-        score = sum_group_rating(member_groups)
-
-        {score, team_number}
-      end)
-      |> Enum.sort()
-
-    case picked do
-      # Single player
-      %{count: 1} ->
-        current_team =
-          if opts[:shuffle_first_pick] do
-            # Filter out any team with a higher rating than the first
-            low_rating = hd(team_skills) |> elem(0)
-
-            team_skills
-            |> Enum.reject(fn {rating, _id} -> rating > low_rating end)
-            |> Enum.shuffle()
-            |> hd
-            |> elem(1)
-          else
-            hd(team_skills)
-            |> elem(1)
-          end
-
-        new_team = [picked | teams[current_team]]
-        new_team_map = Map.put(teams, current_team, new_team)
-
-        names =
-          picked.members
-          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
-
-        new_total = (hd(team_skills) |> elem(0)) + picked.group_rating
-
-        new_logs =
-          logs ++
-            [
-              "Picked #{names} for team #{current_team}, adding #{round(picked.group_rating, 2)} points for new total of #{round(new_total, 2)}"
-            ]
-
-        do_loser_picks(remaining_groups, new_team_map, max_teamsize, new_logs, opts)
-
-      # Groups, so we just merge a bunch of them into teams
-      groups ->
-        # Generate new team map
-        new_team_map =
-          team_skills
-          |> Enum.zip(groups)
-          |> Map.new(fn {{_points, team_number}, group} ->
-            team = teams[team_number] || []
-            {team_number, [group | team]}
-          end)
-
-        # Generate logs
-        extra_logs =
-          team_skills
-          |> Enum.zip(groups)
-          |> Enum.map(fn {{points, team_number}, group} ->
-            names =
-              group.members
-              |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
-
-            new_team_total = points + group.group_rating
-
-            "Group picked #{names} for team #{team_number}, adding #{round(group.group_rating, 2)} points for new total of #{round(new_team_total, 2)}"
-          end)
-
-        new_logs = logs ++ extra_logs
-
-        do_loser_picks(remaining_groups, new_team_map, max_teamsize, new_logs, opts)
-    end
-  end
-
-  @doc """
   Expects a map of %{team_id => rating_value}
 
   Returns the deviation in percentage points between the two teams
@@ -651,26 +270,6 @@ defmodule Teiserver.Battle.BalanceLib do
     end
   end
 
-  # Given a list of groups, return the combined number of members
-  @spec sum_group_membership_size([expanded_group()]) :: non_neg_integer()
-  defp sum_group_membership_size([]), do: 0
-
-  defp sum_group_membership_size(groups) do
-    groups
-    |> Enum.map(fn %{count: count} -> count end)
-    |> Enum.sum()
-  end
-
-  # Given a list of groups, return the combined rating (summed)
-  @spec sum_group_rating([expanded_group()]) :: non_neg_integer()
-  defp sum_group_rating([]), do: 0
-
-  defp sum_group_rating(groups) do
-    groups
-    |> Enum.map(fn %{group_rating: group_rating} -> group_rating end)
-    |> Enum.sum()
-  end
-
   @spec calculate_leaderboard_rating(number(), number()) :: number()
   def calculate_leaderboard_rating(skill, uncertainty) do
     max(skill - 3 * uncertainty, 0)
@@ -701,121 +300,6 @@ defmodule Teiserver.Battle.BalanceLib do
     _method3 = sum + Enum.max(ratings)
     _method4 = sum + mean
     _highest_rank = Enum.max(ratings) * count
-
     sum
-  end
-
-  # Stage one, filter out players notably better/worse than the party
-  @spec find_comparable_group(expanded_group(), [expanded_group()], list()) ::
-          :no_possible_players | :no_possible_combinations | expanded_group()
-  defp find_comparable_group(group, solo_players, opts) do
-    rating_lower_bound =
-      Enum.min(group.ratings) - (opts[:rating_lower_boundary] || @rating_lower_boundary)
-
-    rating_upper_bound =
-      Enum.max(group.ratings) + (opts[:rating_upper_boundary] || @rating_upper_boundary)
-
-    possible_players =
-      solo_players
-      |> Enum.filter(fn solo ->
-        solo.group_rating > rating_lower_bound or solo.group_rating < rating_upper_bound
-      end)
-
-    if Enum.count(possible_players) < group.count do
-      :no_possible_players
-    else
-      filter_down_possibles(group, possible_players, opts)
-    end
-  end
-
-  # Now we've trimmed our playerlist a bit lets check out the different combinations
-  @spec filter_down_possibles(expanded_group(), [expanded_group()], list()) ::
-          :no_possible_combinations | expanded_group()
-  defp filter_down_possibles(group, possible_players, opts) do
-    group_mean = Enum.sum(group.ratings) / Enum.count(group.ratings)
-    group_stddev = Statistics.stdev(group.ratings)
-
-    sorted_possible_players =
-      possible_players
-      |> Enum.sort_by(fn g -> Enum.count(g.members) end, &>=/2)
-
-    all_combinations =
-      make_combinations(group.count, sorted_possible_players)
-
-      # Filter out bad data (parties can cause bad group sizes)
-      |> Stream.filter(fn members ->
-        total_count =
-          members
-          |> Enum.map(fn g -> g.count end)
-          |> Enum.sum()
-
-        cond do
-          total_count > group.count -> false
-          true -> true
-        end
-      end)
-
-      # This part we are getting the relevant stat info to filter on
-      |> Stream.map(fn members ->
-        member_ratings = Enum.map(members, fn %{group_rating: group_rating} -> group_rating end)
-
-        members_mean = Enum.sum(member_ratings) / group.count
-        members_stddev = Statistics.stdev(member_ratings)
-
-        mean_diff = abs(group_mean - members_mean)
-        stddev_diff = abs(group_stddev - members_stddev)
-
-        {members, mean_diff, stddev_diff}
-      end)
-
-      # We now filter on differences in mean and stddev
-      |> Stream.filter(fn {_members, mean_diff, stddev_diff} ->
-        cond do
-          mean_diff > (opts[:mean_diff_max] || @mean_diff_max) -> false
-          stddev_diff > (opts[:stddev_diff_max] || @stddev_diff_max) -> false
-          true -> true
-        end
-      end)
-
-      # Finally we sort
-      |> Enum.sort_by(
-        fn
-          {_members, mean_diff, stddev_diff} -> {mean_diff * stddev_diff, mean_diff, stddev_diff}
-        end,
-        &<=/2
-      )
-
-    case all_combinations do
-      [] ->
-        :no_possible_combinations
-
-      _ ->
-        {selected_group, _, _} = hd(all_combinations)
-
-        # Now turn a list of groups into one group
-        selected_group
-        |> Enum.reduce(%{members: [], ratings: [], count: 0, group_rating: 0}, fn solo, acc ->
-          %{
-            members: acc.members ++ solo.members,
-            ratings: acc.ratings ++ solo.ratings,
-            count: acc.count + solo.count,
-            group_rating: acc.group_rating + solo.group_rating
-          }
-        end)
-    end
-  end
-
-  # First argument is the size of each combination
-  # Second is the list of items to make a combination from
-  @spec make_combinations(integer(), list) :: [list]
-  defp make_combinations(0, _), do: [[]]
-  defp make_combinations(_, []), do: []
-
-  defp make_combinations(n, [x | xs]) do
-    if n < 0 do
-      [[]]
-    else
-      for(y <- make_combinations(n - x.count, xs), do: [x | y]) ++ make_combinations(n, xs)
-    end
   end
 end

--- a/lib/balance_lib.ex
+++ b/lib/balance_lib.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Battle.BalanceLib do
   alias Teiserver.Game.MatchRatingLib
   alias Teiserver.Battle.LoserPicksAlgorithm
   alias Teiserver.Battle.CheekySwitcherAlgorithm
+  alias Teiserver.Battle.BruteForceAlgorithm
   import Central.Helpers.NumberHelper, only: [int_parse: 1]
   import Teiserver.Battle.BalanceUtil
 
@@ -55,12 +56,17 @@ defmodule Teiserver.Battle.BalanceLib do
         }
       end)
 
+    # raise "Call"
+    IO.inspect(opts, label: "opts")
     {team_groups, logs} =
       case opts[:algorithm] || :loser_picks do
+        :loser_picks ->
+          IO.inspect("Running loser picks")
+          LoserPicksAlgorithm.loser_picks(expanded_groups, team_count, opts)
         :cheeky_switcher ->
           CheekySwitcherAlgorithm.cheeky_switcher(expanded_groups, team_count, opts)
-        :loser_picks ->
-          LoserPicksAlgorithm.loser_picks(expanded_groups, team_count, opts)
+        :brute_force ->
+          BruteForceAlgorithm.brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts)
       end
 
     team_players =

--- a/lib/balance_lib.ex
+++ b/lib/balance_lib.ex
@@ -57,11 +57,9 @@ defmodule Teiserver.Battle.BalanceLib do
       end)
 
     # raise "Call"
-    IO.inspect(opts, label: "opts")
     {team_groups, logs} =
       case opts[:algorithm] || :loser_picks do
         :loser_picks ->
-          IO.inspect("Running loser picks")
           LoserPicksAlgorithm.loser_picks(expanded_groups, team_count, opts)
         :cheeky_switcher ->
           CheekySwitcherAlgorithm.cheeky_switcher(expanded_groups, team_count, opts)

--- a/lib/balance_lib.ex
+++ b/lib/balance_lib.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Battle.BalanceLib do
   alias Teiserver.Game.MatchRatingLib
   alias Teiserver.Battle.LoserPicksAlgorithm
   alias Teiserver.Battle.CheekySwitcherAlgorithm
+  alias Teiserver.Battle.CheekySwitcherSmartAlgorithm
   alias Teiserver.Battle.BruteForceAlgorithm
   import Central.Helpers.NumberHelper, only: [int_parse: 1]
   import Teiserver.Battle.BalanceUtil
@@ -67,6 +68,8 @@ defmodule Teiserver.Battle.BalanceLib do
           CheekySwitcherAlgorithm.cheeky_switcher(expanded_groups, team_count, opts)
         :cheeky_switcher_rating ->
           CheekySwitcherAlgorithm.cheeky_switcher_rating(expanded_groups, team_count, opts)
+        :cheeky_switcher_smart ->
+          CheekySwitcherSmartAlgorithm.cheeky_switcher(expanded_groups, team_count, opts)
         :brute_force ->
           BruteForceAlgorithm.brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts)
       end

--- a/lib/balance_lib.ex
+++ b/lib/balance_lib.ex
@@ -6,7 +6,7 @@ defmodule Teiserver.Battle.BalanceLib do
   alias Teiserver.Account
   alias Teiserver.Game.MatchRatingLib
   alias Teiserver.Battle.LoserPicksAlgorithm
-  alias Teiserver.Battle.PartyPreserverAlgorithm
+  alias Teiserver.Battle.CheekySwitcherAlgorithm
   import Central.Helpers.NumberHelper, only: [int_parse: 1]
   import Teiserver.Battle.BalanceUtil
 
@@ -57,8 +57,8 @@ defmodule Teiserver.Battle.BalanceLib do
 
     {team_groups, logs} =
       case opts[:algorithm] || :loser_picks do
-        :party_preserver ->
-          PartyPreserverAlgorithm.party_preserver(expanded_groups, team_count, opts)
+        :cheeky_switcher ->
+          CheekySwitcherAlgorithm.cheeky_switcher(expanded_groups, team_count, opts)
         :loser_picks ->
           LoserPicksAlgorithm.loser_picks(expanded_groups, team_count, opts)
       end

--- a/lib/balance_util.ex
+++ b/lib/balance_util.ex
@@ -80,6 +80,8 @@ defmodule Teiserver.Battle.BalanceUtil do
   end
 
   @spec max_team_rating_difference(team_map()) :: non_neg_integer()
+  def max_team_rating_difference([]) do 0 end
+  def max_team_rating_difference([_team]) do 0 end
   def max_team_rating_difference(teams) do
     teams
     |> Enum.map(fn {_k, team_groups} -> sum_group_rating(team_groups) end)
@@ -128,6 +130,21 @@ defmodule Teiserver.Battle.BalanceUtil do
     |> Map.values()
     |> Enum.map(fn groups -> count_parties(groups) end)
     |> Enum.sum()
+  end
+
+  def team_ratings(teams) do
+    teams
+    |> Enum.map(fn {_id, groups} -> sum_group_rating(groups) end)
+  end
+
+  def team_means(teams) do
+    teams
+    |> Enum.map(fn {_id, groups} -> sum_group_rating(groups) / sum_group_membership_size(groups) end)
+  end
+
+  def team_stddevs(teams) do
+    teams
+    |> Enum.map(fn {_id, groups} -> Statistics.stdev(Enum.flat_map(groups, fn group -> group.ratings end)) end)
   end
 
   @spec has_parties(team_map()) :: boolean()
@@ -210,14 +227,14 @@ defmodule Teiserver.Battle.BalanceUtil do
     |> Enum.reject(fn {_, index} -> index in combo_b_indices end)
     |> Enum.map(fn {element, _} -> element end)
 
-    IO.inspect(%{
-      group_b_combo: group_b_combo,
-      group_a_combo: group_a_combo,
-      team_a_groups_without_combo: team_a_groups_without_combo,
-      combo_b_groups: combo_b_groups,
-      team_b_groups_without_combo: team_b_groups_without_combo,
-      combo_a_groups: combo_a_groups
-    }, label: "switch_group_combos_between_teams")
+    # IO.inspect(%{
+    #   group_b_combo: group_b_combo,
+    #   group_a_combo: group_a_combo,
+    #   team_a_groups_without_combo: team_a_groups_without_combo,
+    #   combo_b_groups: combo_b_groups,
+    #   team_b_groups_without_combo: team_b_groups_without_combo,
+    #   combo_a_groups: combo_a_groups
+    # }, label: "switch_group_combos_between_teams")
     teams
     |> Map.put(team_a_id, team_a_groups_without_combo ++ combo_b_groups)
     |> Map.put(team_b_id, team_b_groups_without_combo ++ combo_a_groups)

--- a/lib/balance_util.ex
+++ b/lib/balance_util.ex
@@ -1,0 +1,156 @@
+defmodule Teiserver.Battle.BalanceUtil do
+  @moduledoc """
+  Documentation for BalanceUtil.
+  """
+
+  alias Central.Config
+
+  # Upper boundary is how far above the group value the members can be, lower is how far below it
+  # these values are in general used for group pairing where we look at making temporary groups on
+  # each team to make the battle fair
+  @rating_lower_boundary 3
+  @rating_upper_boundary 5
+
+  @mean_diff_max 5
+  @stddev_diff_max 3
+
+  # Fuzz multiplier is used by the BalanceServer to prevent two games being completely identical
+  # teams. It is defaulted here as the server uses this library to get defaults
+  @fuzz_multiplier 0.5
+
+  # When set to true, if there are any teams with 0 points (first pick) it randomises
+  # which one will get to pick first
+  @shuffle_first_pick true
+
+  @type rating_value() :: float()
+  @type player_group() :: %{T.userid() => rating_value()}
+  @type expanded_group() :: %{
+          members: [T.userid()],
+          ratings: [rating_value()],
+          group_rating: rating_value(),
+          count: non_neg_integer()
+        }
+  @type expanded_group_or_pair() :: expanded_group() | {expanded_group(), expanded_group()}
+  @type team_map() :: %{T.team_id() => [expanded_group()]}
+
+  # These are default values and can be overridden as part of the call to create_balance()
+  @spec defaults() :: map()
+  def defaults() do
+    %{
+      max_deviation: Config.get_site_config_cache("teiserver.Max deviation"),
+      rating_lower_boundary: @rating_lower_boundary,
+      rating_upper_boundary: @rating_upper_boundary,
+      mean_diff_max: @mean_diff_max,
+      stddev_diff_max: @stddev_diff_max,
+      fuzz_multiplier: @fuzz_multiplier,
+      shuffle_first_pick: @shuffle_first_pick
+    }
+  end
+
+  # Given a list of groups, return the combined number of members
+  @spec sum_group_membership_size([expanded_group()]) :: non_neg_integer()
+  def sum_group_membership_size([]), do: 0
+
+  def sum_group_membership_size(groups) do
+    groups
+    |> Enum.map(fn %{count: count} -> count end)
+    |> Enum.sum()
+  end
+
+  # Given a list of groups, return the combined rating (summed)
+  @spec sum_group_rating([expanded_group()]) :: non_neg_integer()
+  def sum_group_rating([]), do: 0
+
+  def sum_group_rating(groups) do
+    groups
+    |> Enum.map(fn %{group_rating: group_rating} -> group_rating end)
+    |> Enum.sum()
+  end
+
+  @spec min_max_difference([non_neg_integer()]) :: non_neg_integer()
+  def min_max_difference(list) do
+    Enum.max(list) - Enum.min(list)
+  end
+
+  @spec max_team_member_count_difference(team_map()) :: non_neg_integer()
+  def max_team_member_count_difference(teams) do
+    teams
+    |> Enum.map(fn {_k, team_groups} -> sum_group_membership_size(team_groups) end)
+    |> min_max_difference()
+  end
+
+  @spec max_team_rating_difference(team_map()) :: non_neg_integer()
+  def max_team_rating_difference(teams) do
+    teams
+    |> Enum.map(fn {_k, team_groups} -> sum_group_rating(team_groups) end)
+    |> min_max_difference()
+  end
+
+  @spec make_empty_teams(non_neg_integer()) :: team_map()
+  def make_empty_teams(team_count) do
+    Range.new(1, team_count)
+      |> Map.new(fn i ->
+        {i, []}
+      end)
+  end
+
+  @spec sort_groups_by_rating([expanded_group()]) :: [expanded_group()]
+  def sort_groups_by_rating(groups) do
+    Enum.sort_by(
+      groups,
+      fn %{group_rating: rating} -> rating end,
+      :desc)
+  end
+
+  @spec sort_groups_by_count([expanded_group()]) :: [expanded_group()]
+  def sort_groups_by_count(groups) do
+    Enum.sort_by(
+      groups,
+      fn %{count: count} -> count end,
+      :desc)
+  end
+
+  @spec unwind_teams_to_groups(team_map()) :: [expanded_group()]
+  def unwind_teams_to_groups(teams) do
+    Enum.flat_map(teams, fn {_k, team_groups} -> team_groups end)
+  end
+
+  @spec has_parties(team_map()) :: boolean()
+  def has_parties(teams) do
+    teams
+    |> Enum.any?(fn {_k, team_groups} ->
+      Enum.any?(team_groups, fn %{count: count} -> count > 1 end) end)
+  end
+
+  @spec replace_team_group_at_index(team_map(), T.team_id(), non_neg_integer(), expanded_group()) :: team_map()
+  def replace_team_group_at_index(teams, team_id, group_index, group) do
+    Map.put(teams, team_id, List.replace_at(teams[team_id], group_index, group))
+  end
+
+  @spec switch_group_pair_between_teams(team_map(), T.team_id(), non_neg_integer(), T.team_id(), non_neg_integer()) :: team_map()
+  def switch_group_pair_between_teams(
+    teams,
+    team_a_id,
+    group_a_index,
+    group_b_id,
+    group_b_index) do
+    team_a_groups = teams[team_a_id]
+    group_a = Enum.at(team_a_groups, group_a_index)
+    team_b_groups = teams[group_b_id]
+    group_b = Enum.at(team_b_groups, group_b_index)
+
+    replace_team_group_at_index(teams, team_a_id, group_a_index, group_b)
+    |> replace_team_group_at_index(group_b_id, group_b_index, group_a)
+  end
+
+  @spec lowest_highest_rated_teams(team_map()) :: {{T.team_id(), non_neg_integer()}, {T.team_id(), non_neg_integer()}}
+  def lowest_highest_rated_teams(teams) do
+    teams
+    |> IO.inspect()
+    |> Enum.map(fn {team_id, team_groups} ->
+      {team_id, sum_group_rating(team_groups)}
+    end)
+    |> IO.inspect()
+    |> Enum.min_max_by(fn {_team_id, rating} -> rating end)
+  end
+end

--- a/lib/balance_util.ex
+++ b/lib/balance_util.ex
@@ -26,6 +26,7 @@ defmodule Teiserver.Battle.BalanceUtil do
   @type player_group() :: %{T.userid() => rating_value()}
   @type expanded_group() :: %{
           members: [T.userid()],
+          names: [charlist()],
           ratings: [rating_value()],
           group_rating: rating_value(),
           count: non_neg_integer()
@@ -117,14 +118,19 @@ defmodule Teiserver.Battle.BalanceUtil do
     Enum.flat_map(teams, fn {_k, team_groups} -> team_groups end)
   end
 
-  @spec count_parties([expanded_group()]) :: non_neg_integer()
-  def count_parties(groups) do
+  @spec get_parties([expanded_group()]) :: [expanded_group()]
+  def get_parties(groups) do
     groups
     |> Enum.filter(fn group -> group.count > 1 end)
-    |> length()
   end
 
   @spec count_parties([expanded_group()]) :: non_neg_integer()
+  def count_parties(groups) do
+    get_parties(groups)
+    |> length()
+  end
+
+  @spec count_parties_in_teams(team_map()) :: number()
   def count_parties_in_teams(teams) do
     teams
     |> Map.values()
@@ -227,14 +233,6 @@ defmodule Teiserver.Battle.BalanceUtil do
     |> Enum.reject(fn {_, index} -> index in combo_b_indices end)
     |> Enum.map(fn {element, _} -> element end)
 
-    # IO.inspect(%{
-    #   group_b_combo: group_b_combo,
-    #   group_a_combo: group_a_combo,
-    #   team_a_groups_without_combo: team_a_groups_without_combo,
-    #   combo_b_groups: combo_b_groups,
-    #   team_b_groups_without_combo: team_b_groups_without_combo,
-    #   combo_a_groups: combo_a_groups
-    # }, label: "switch_group_combos_between_teams")
     teams
     |> Map.put(team_a_id, team_a_groups_without_combo ++ combo_b_groups)
     |> Map.put(team_b_id, team_b_groups_without_combo ++ combo_a_groups)

--- a/lib/cheeky_switcher.ex
+++ b/lib/cheeky_switcher.ex
@@ -1,5 +1,6 @@
 defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   import Teiserver.Battle.BalanceUtil
+  alias Teiserver.Account
 
   @max_switches 3
 
@@ -7,7 +8,7 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   @type team_map :: BalanceUtils.team_map
   @type group_list :: [expanded_group_or_pair()]
 
-  @spec acceptable_teams(%{optional(any) => [map]}) :: boolean
+  @spec acceptable_teams(team_map()) :: {boolean, number(), number()}
   def acceptable_teams(teams) do
     total_ratings = teams
     |> Enum.map(fn {_k, groups} -> sum_group_rating(groups) end)
@@ -20,38 +21,86 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
     {percentage_diff < 5, rating_diff, percentage_diff}
   end
 
-  @spec cheeky_switcher(
-          [%{count: non_neg_integer, group_rating: float, members: list, ratings: [float]}],
-          number
-        ) :: {[] | %{optional(any) => list}, list}
-  def cheeky_switcher([], _team_count) do {[], []} end
-  def cheeky_switcher([], _team_count, _opts) do {[], []} end
-  def cheeky_switcher(expanded_groups, team_count) do do_cheeky_switcher(expanded_groups, team_count, [], []) end
-  def cheeky_switcher(expanded_groups, team_count, opts) do do_cheeky_switcher(expanded_groups, team_count, opts, []) end
+  @spec cheeky_switcher([expanded_group_or_pair()], number, %{}) :: {team_map(), list()}
+  def cheeky_switcher(expanded_groups, team_count, opts) do
+    groups_with_names = expanded_groups
+    |> Enum.map(fn group ->
+      Map.put(group, :names, Enum.map(group.members, fn id ->
+        Account.get_username_by_id(id)
+      end))
+    end)
 
-  def do_cheeky_switcher(expanded_groups, team_count, opts, log) do
+    do_cheeky_switcher(
+      groups_with_names,
+      team_count,
+      opts,
+      [])
+  end
+
+  def do_cheeky_switcher(expanded_groups, team_count, opts, log, start_time \\ System.system_time(:microsecond)) do
     {teams, log} = expanded_groups
     # |> sort_groups_by_rating()
     |> sort_groups_by_count()
-    # |> IO.inspect(label: "Sorted by rating", charlists: :as_lists)
+    # |> IO.inspect(label: "Sorted by rating, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
     |> place_groups_to_smallest_teams(make_empty_teams(team_count), log)
-    # |> IO.inspect(label: "Placed groups", charlists: :as_lists)
+    # |> IO.inspect(label: "Placed groups, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
     |> switch_best_rating_diffs()
+    # |> IO.inspect(label: "Switched best rating diffs, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
 
     {is_acceptable, rating_diff, percentage_diff} = acceptable_teams(teams)
 
     parties_left = count_parties_in_teams(teams)
 
-    # IO.inspect(teams, label: "Switched all groups, current diff: #{rating_diff}, parties left: #{parties_left}", charlists: :as_lists)
+    # IO.inspect(teams, label: "Switched all groups, current diff: #{rating_diff}, parties left: #{parties_left}, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
 
     if is_acceptable or parties_left <= 0 do
-      {teams, log  ++ ["Acceptable rating difference of #{rating_diff} (#{percentage_diff} %)."]}
+      {teams, log  ++ ["Acceptable rating difference of #{round(100 * rating_diff) / 100} (#{round(100 * percentage_diff) / 100} %)."]}
     else
+      {groups_without_largest_party, log} = teams_to_groups_without_largest_party(teams, log ++ ["Unacceptable rating difference of #{round(rating_diff)} (#{round(percentage_diff)} %) with current parties."])
       do_cheeky_switcher(
-        teams_to_groups_without_largest_party(teams),
+        groups_without_largest_party,
         team_count,
         opts,
-        log ++ ["Unacceptable rating difference of #{rating_diff} (#{percentage_diff} %) with current parties, retrying without largest party"])
+        log,
+        start_time)
+    end
+  end
+
+  @spec cheeky_switcher_rating([expanded_group_or_pair()], number, %{}) :: {team_map(), list()}
+  def cheeky_switcher_rating(expanded_groups, team_count, opts) do
+    groups_with_names = expanded_groups
+      |> Enum.map(fn group ->
+        Map.put(group, :names, Enum.map(group.members, fn id ->
+          Account.get_username_by_id(id)
+        end))
+      end)
+    do_cheeky_switcher_rating(groups_with_names, team_count, opts, [])
+  end
+  def do_cheeky_switcher_rating(expanded_groups, team_count, opts, log, start_time \\ System.system_time(:microsecond)) do
+    {teams, log} = expanded_groups
+    |> sort_groups_by_rating()
+    # |> IO.inspect(label: "Sorted by rating, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
+    |> place_groups_to_smallest_teams(make_empty_teams(team_count), log)
+    # |> IO.inspect(label: "Placed groups, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
+    |> switch_best_rating_diffs()
+    # |> IO.inspect(label: "Switched best rating diffs, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
+
+    {is_acceptable, rating_diff, percentage_diff} = acceptable_teams(teams)
+
+    parties_left = count_parties_in_teams(teams)
+
+    # IO.inspect(teams, label: "Switched all groups, current diff: #{rating_diff}, parties left: #{parties_left}, t=#{System.system_time(:microsecond) - start_time}]", charlists: :as_lists)
+
+    if is_acceptable or parties_left <= 0 do
+      {teams, log  ++ ["Acceptable rating difference of #{round(100 * rating_diff) / 100} (#{round(100 * percentage_diff) / 100} %)."]}
+    else
+      {groups_without_largest_party, log} = teams_to_groups_without_largest_party(teams, log ++ ["Unacceptable rating difference of #{round(rating_diff)} (#{round(percentage_diff)} %) with current parties."])
+      do_cheeky_switcher(
+        groups_without_largest_party,
+        team_count,
+        opts,
+        log,
+        start_time)
     end
   end
 
@@ -59,7 +108,6 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   @spec switch_best_rating_diffs({team_map(), list()}) :: {team_map(), list()}
   defp switch_best_rating_diffs({teams, log}) do
     team_rating_diff = max_team_rating_difference(teams)
-    # IO.inspect(teams, label: "Team rating diff #{team_rating_diff}", charlists: :as_lists)
 
     if team_rating_diff == 0 do
       {teams, log ++ ["Teams already balanced"]}
@@ -85,33 +133,33 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
           highest_team_combo: highest_team_combo,
           lowest_team_combo: lowest_team_combo,
           lowest_team_id: lowest_team_id,
-          combo_switch_diff: combo_switch_diff,
-          best_diff: best_diff
+          combo_switch_diff: _combo_switch_diff,
+          best_diff: _best_diff
         } ->
-          lowest_combo_indices = lowest_team_combo
-            |> Enum.map(fn {_g, i} -> to_string(i) end)
-            |> Enum.join(", ")
+          # lowest_combo_indices = lowest_team_combo
+          #   |> Enum.map(fn {_g, i} -> to_string(i) end)
+          #   |> Enum.join(", ")
 
-          highest_combo_indices = highest_team_combo
-            |> Enum.map(fn {_g, i} -> to_string(i) end)
-            |> Enum.join(", ")
+          # highest_combo_indices = highest_team_combo
+          #   |> Enum.map(fn {_g, i} -> to_string(i) end)
+          #   |> Enum.join(", ")
 
           # Found a pair, so switch them
           # IO.inspect( %{ highest_team_id: highest_team_id, highest_team_combo: highest_team_combo, lowest_team_id: lowest_team_id, lowest_team_combo: lowest_team_combo, combo_switch_diff: combo_switch_diff, best_diff: best_diff, teams: teams, highest_combo_indices: highest_combo_indices, lowest_combo_indices: lowest_combo_indices, }, label: "Best pair to switch", charlists: :as_lists)
 
           lowest_team_members = lowest_team_combo
           |> Enum.map(fn {group, _} ->
-            group.members
+            group.names
             |> Enum.with_index()
-            |> Enum.map(fn {member, i} -> "#{member}[#{Enum.at(group.ratings,i)}]" end)
+            |> Enum.map(fn {name, i} -> "#{name}[#{Enum.at(group.ratings,i)}]" end)
           end)
           |> List.flatten()
           |> Enum.join(",")
         highest_team_members = highest_team_combo
           |> Enum.map(fn {group, _} ->
-            group.members
+            group.names
             |> Enum.with_index()
-            |> Enum.map(fn {member, i} -> "#{member}[#{Enum.at(group.ratings,i)}]" end)
+            |> Enum.map(fn {name, i} -> "#{name}[#{Enum.at(group.ratings,i)}]" end)
           end)
           |> List.flatten()
           |> Enum.join(",")
@@ -131,16 +179,17 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
 
   # Find a pair of groups from the lowest ranked team and highest ranked team
   # that have a rating difference close to equalizing_diff
-  @spec find_best_pair_to_switch(team_map(), non_neg_integer()) :: map()
+  @spec find_best_pair_to_switch(team_map(), float()) :: map()
   defp find_best_pair_to_switch(teams, equalizing_diff) do
-    {{lowest_team_id, rating_l}, {highest_team_id, rating_h}} = lowest_highest_rated_teams(teams)
+    {{lowest_team_id, _rating_l}, {highest_team_id, _rating_h}} = lowest_highest_rated_teams(teams)
     highest_team_groups = teams[highest_team_id]
     lowest_team_groups = teams[lowest_team_id]
     # IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest team #{lowest_team_id}: #{rating_l}. Equalizing diff: #{equalizing_diff}", label: "Finding best pair to switch")
 
-    biggest_group_size = highest_team_groups
-      |> Enum.map(fn group -> group.count end)
-      |> Enum.max()
+    # biggest_group_size = highest_team_groups
+    #   |> Enum.map(fn group -> group.count end)
+    #   |> Enum.max()
+    biggest_group_size = floor(Enum.count(teams) / 2)
 
     highest_team_groups_combos = make_group_combinations(
       highest_team_groups,
@@ -223,10 +272,11 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
         # IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party", charlists: :as_lists)
         # Break up the biggest party (there has to be a party) that obstructs
         # making equal teams and restart grouping, which now should be easier to get even.
+        {teams_without_largest_party, log} = teams_to_groups_without_largest_party(teams, log ++ ["Teams are not even, breaking up largest party"])
         place_groups_to_smallest_teams(
-          teams_to_groups_without_largest_party(teams),
+          teams_without_largest_party,
           make_empty_teams(map_size(teams)),
-          log ++ ["Teams are not even, breaking up largest party"]
+          log
         )
     end
   end
@@ -241,41 +291,42 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   end
 
   defp make_pick_logs(team_key, next_group) do
-    {placement_logs, _r} = next_group.members
+    {placement_logs, _r} = next_group.names
       |> Enum.with_index()
-      |> Enum.reduce({[], 0}, fn {member, i}, {group_log, acc_rating} ->
+      |> Enum.reduce({[], 0}, fn {name, i}, {group_log, acc_rating} ->
         new_acc_rating = acc_rating + Enum.at(next_group.ratings, i)
-        {group_log ++ ["Picked #{member} for team #{team_key}, adding #{Enum.at(next_group.ratings, i)} points for a new total of #{new_acc_rating}"], new_acc_rating}
+        {group_log ++ ["Picked #{name} for team #{team_key}, adding #{Enum.at(next_group.ratings, i)} points for a new total of #{new_acc_rating}"], new_acc_rating}
       end)
     placement_logs
   end
 
-  @spec teams_to_groups_without_largest_party(map()) :: group_list()
-  defp teams_to_groups_without_largest_party(teams) do
-    teams
+  @spec teams_to_groups_without_largest_party(map(), list()) :: {group_list(), list()}
+  defp teams_to_groups_without_largest_party(teams, log) do
+    {new_groups, log} = teams
     # Return to the list of groups
     |> unwind_teams_to_groups()
     # Sort by party size
     |> sort_groups_by_count()
     # Break up the first and largest party
-    |> break_up_first_party()
-    # Sort again by rating
-    # |> sort_groups_by_rating()
-    |> sort_groups_by_count()
+    |> break_up_first_party(log)
+
+    # Sort again by size
+    {sort_groups_by_count(new_groups), log}
   end
 
-  defp break_up_first_party([]) do
-    []
+  defp break_up_first_party([], log) do
+    {[], log}
   end
 
-  defp break_up_first_party([group | rest_groups]) do
-    rest_groups ++ Enum.map(Enum.with_index(group.members),
+  defp break_up_first_party([group | rest_groups], log) do
+    {rest_groups ++ Enum.map(Enum.with_index(group.members),
       fn {member_id, i} -> %{
         count: 1,
+        names: [Enum.at(group.names, i)],
         group_rating: Enum.at(group.ratings, i),
         ratings: [Enum.at(group.ratings, i)],
         members: [member_id]
-      } end)
+      } end), log ++ ["Breaking up party [#{Enum.join(group.names, ", ")}]"]}
   end
 
   @spec add_group_to_team(team_map(), expanded_group_or_pair(), atom()) :: team_map()

--- a/lib/cheeky_switcher.ex
+++ b/lib/cheeky_switcher.ex
@@ -24,11 +24,11 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   def cheeky_switcher(expanded_groups, team_count, log) do
     {teams, log} = expanded_groups
     |> sort_groups_by_rating()
-    |> IO.inspect(label: "Sorted by rating", charlists: :as_lists)
+    # |> IO.inspect(label: "Sorted by rating", charlists: :as_lists)
     |> place_groups_to_smallest_teams(make_empty_teams(team_count), log)
-    |> IO.inspect(label: "Placed groups", charlists: :as_lists)
+    # |> IO.inspect(label: "Placed groups", charlists: :as_lists)
     |> switch_best_rating_diffs()
-    |> IO.inspect(label: "Switched all groups, exiting", charlists: :as_lists)
+    # |> IO.inspect(label: "Switched all groups, exiting", charlists: :as_lists)
 
     parties_left = count_parties_in_teams(teams)
 
@@ -46,7 +46,7 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   @spec switch_best_rating_diffs({team_map(), list()}) :: {team_map(), list()}
   defp switch_best_rating_diffs({teams, log}) do
     team_rating_diff = max_team_rating_difference(teams)
-    IO.inspect(teams, label: "Team rating diff #{team_rating_diff}", charlists: :as_lists)
+    # IO.inspect(teams, label: "Team rating diff #{team_rating_diff}", charlists: :as_lists)
 
     if team_rating_diff == 0 do
       {teams, log ++ ["Teams already balanced"]}
@@ -84,20 +84,20 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
             |> Enum.join(", ")
 
           # Found a pair, so switch them
-          IO.inspect(
-            %{
-              highest_team_id: highest_team_id,
-              highest_team_combo: highest_team_combo,
-              lowest_team_id: lowest_team_id,
-              lowest_team_combo: lowest_team_combo,
-              combo_switch_diff: combo_switch_diff,
-              best_diff: best_diff,
-              teams: teams,
-              highest_combo_indices: highest_combo_indices,
-              lowest_combo_indices: lowest_combo_indices,
-            },
-            label: "Best pair to switch",
-            charlists: :as_lists)
+          # IO.inspect(
+          #   %{
+          #     highest_team_id: highest_team_id,
+          #     highest_team_combo: highest_team_combo,
+          #     lowest_team_id: lowest_team_id,
+          #     lowest_team_combo: lowest_team_combo,
+          #     combo_switch_diff: combo_switch_diff,
+          #     best_diff: best_diff,
+          #     teams: teams,
+          #     highest_combo_indices: highest_combo_indices,
+          #     lowest_combo_indices: lowest_combo_indices,
+          #   },
+          #   label: "Best pair to switch",
+          #   charlists: :as_lists)
 
           # Switch the best pair
           {switch_group_combos_between_teams(
@@ -119,7 +119,7 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
     {{lowest_team_id, rating_l}, {highest_team_id, rating_h}} = lowest_highest_rated_teams(teams)
     highest_team_groups = teams[highest_team_id]
     lowest_team_groups = teams[lowest_team_id]
-    IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest team #{lowest_team_id}: #{rating_l}. Equalizing diff: #{equalizing_diff}", label: "Finding best pair to switch")
+    # IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest team #{lowest_team_id}: #{rating_l}. Equalizing diff: #{equalizing_diff}", label: "Finding best pair to switch")
 
     biggest_group_size = highest_team_groups
       |> Enum.map(fn group -> group.count end)
@@ -211,7 +211,7 @@ defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
       0 -> {teams, log}
       1 -> {teams, log}
       _ ->
-        IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party", charlists: :as_lists)
+        # IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party", charlists: :as_lists)
         # Break up the biggest party (there has to be a party) that obstructs
         # making equal teams and restart grouping, which now should be easier to get even.
         place_groups_to_smallest_teams(

--- a/lib/cheeky_switcher.ex
+++ b/lib/cheeky_switcher.ex
@@ -1,4 +1,4 @@
-defmodule Teiserver.Battle.PartyPreserverAlgorithm do
+defmodule Teiserver.Battle.CheekySwitcherAlgorithm do
   import Teiserver.Battle.BalanceUtil
 
   @max_switches 3
@@ -11,13 +11,17 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
     max_team_rating_difference(teams) < 5
   end
 
-  def party_preserver([], _team_count, _opts) do
+  def cheeky_switcher([], _team_count, _opts) do
     {[], []}
   end
 
-  @spec party_preserver(group_list(), number(), list()) :: {team_map(), list()}
-  def party_preserver(expanded_groups, team_count) do party_preserver(expanded_groups, team_count, []) end
-  def party_preserver(expanded_groups, team_count, log) do
+  @spec cheeky_switcher(group_list(), number(), list()) :: {team_map(), list()}
+  @spec cheeky_switcher(
+          [%{count: non_neg_integer, group_rating: float, members: list, ratings: [float]}],
+          number
+        ) :: {[] | %{optional(any) => list}, list}
+  def cheeky_switcher(expanded_groups, team_count) do cheeky_switcher(expanded_groups, team_count, []) end
+  def cheeky_switcher(expanded_groups, team_count, log) do
     {teams, log} = expanded_groups
     |> sort_groups_by_rating()
     |> IO.inspect(label: "Sorted by rating", charlists: :as_lists)
@@ -31,7 +35,7 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
     if acceptable_teams(teams) or parties_left <= 0 do
       {teams, log}
     else
-      party_preserver(
+      cheeky_switcher(
         teams_to_groups_without_largest_party(teams),
         team_count,
         log ++ ["Unacceptable rating difference of #{max_team_rating_difference(teams)} with current parties, retrying without largest party"])

--- a/lib/et_tu_brute_force.ex
+++ b/lib/et_tu_brute_force.ex
@@ -15,13 +15,12 @@ defmodule Teiserver.Battle.BruteForceAlgorithm do
   def brute_force_dont_use_in_production_for_the_love_of_bar([], _team_count, _opts, _log) do
     {[], []}
   end
-  def brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts, log) do
+  def brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, _opts, log) do
     # We're going to brute force all possible combinations of teams
     # and then pick the best one
     # This is a very dumb approach and will be slow for large groups
     # but it's a good point of comparison for the other algorithms
 
-    # IO.inspect(team_count, label: "brute_force_dont_use_in_production_for_the_love_of_bar, team count:")
     team_member_size = ceil(sum_group_membership_size(expanded_groups) / team_count)
 
     team_alternatives = expanded_groups
@@ -31,11 +30,8 @@ defmodule Teiserver.Battle.BruteForceAlgorithm do
     end)
     |> Enum.with_index()
     |> make_list_of_team_combinations(team_count)
-    # |> IO.inspect()
     |> Enum.sort_by(fn team -> team[:score] end, :asc)
     |> Enum.take(3)
-
-    # IO.inspect(teams)
 
     {hd(team_alternatives).team_groups, log}
   end
@@ -63,7 +59,6 @@ defmodule Teiserver.Battle.BruteForceAlgorithm do
           1 => first_candidate,
           2 => second_team,
         }
-        # IO.inspect(teams, label: "teams")
         deviation = max_team_rating_difference(team_groups)
         stdevs = team_stddevs(team_groups)
         score = deviation * 10 + Enum.max(stdevs)
@@ -78,7 +73,6 @@ defmodule Teiserver.Battle.BruteForceAlgorithm do
       end
     end)
     |> Enum.filter(fn x -> x != nil end)
-    # IO.inspect(valid_candidates, label: "valid_candidates")
     make_list_of_team_combinations(rest_candidates, team_count, teams ++ valid_candidates)
   end
 

--- a/lib/et_tu_brute_force.ex
+++ b/lib/et_tu_brute_force.ex
@@ -1,0 +1,94 @@
+defmodule Teiserver.Battle.BruteForceAlgorithm do
+  import Teiserver.Battle.BalanceUtil
+
+  @max_switches 3
+
+  @type expanded_group_or_pair :: BalanceUtils.expanded_group_or_pair
+  @type team_map :: BalanceUtils.team_map
+  @type group_list :: [expanded_group_or_pair()]
+
+
+  def brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts \\ [])
+  def brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts) do
+    brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts, [])
+  end
+  def brute_force_dont_use_in_production_for_the_love_of_bar([], _team_count, _opts, _log) do
+    {[], []}
+  end
+  def brute_force_dont_use_in_production_for_the_love_of_bar(expanded_groups, team_count, opts, log) do
+    # We're going to brute force all possible combinations of teams
+    # and then pick the best one
+    # This is a very dumb approach and will be slow for large groups
+    # but it's a good point of comparison for the other algorithms
+
+    # IO.inspect(team_count, label: "brute_force_dont_use_in_production_for_the_love_of_bar, team count:")
+    team_member_size = ceil(sum_group_membership_size(expanded_groups) / team_count)
+
+    team_alternatives = expanded_groups
+    |> make_group_combinations(team_member_size)
+    |> Enum.map(fn team ->
+      Enum.map(team, fn {group, _i} -> group end)
+    end)
+    |> Enum.with_index()
+    |> make_list_of_team_combinations(team_count)
+    # |> IO.inspect()
+    |> Enum.sort_by(fn team -> team[:score] end, :asc)
+    |> Enum.take(3)
+
+    # IO.inspect(teams)
+
+    {hd(team_alternatives).team_groups, log}
+  end
+
+  @spec make_list_of_team_combinations([{any, any}], any) :: any
+  def make_list_of_team_combinations(team_candidates, team_count) do make_list_of_team_combinations(team_candidates, team_count, []) end
+  @spec make_list_of_team_combinations([{any, any}], any, any) :: any
+  def make_list_of_team_combinations([], _team_count, teams) do teams end
+  def make_list_of_team_combinations([first_candidate | rest_candidates], team_count, teams) do
+    {first_candidate, idx} = first_candidate
+    # Combine two and two groups into a team
+    # This is a recursive function that will combine all groups into teams
+    # and then return a list of all possible combinations of teams
+    # The result is a list of lists of teams
+    # Example:
+    #   [[team1, team2], [team3, team4], [team5, team6]]
+    #   [[team1, team2, team3], [team4, team5, team6]]
+
+    valid_candidates = rest_candidates
+    |> Enum.map(fn {second_team, _i} ->
+      if has_overlapping_members(first_candidate, second_team) do
+        nil
+      else
+        team_groups =  %{
+          1 => first_candidate,
+          2 => second_team,
+        }
+        # IO.inspect(teams, label: "teams")
+        deviation = max_team_rating_difference(team_groups)
+        stdevs = team_stddevs(team_groups)
+        score = deviation * 10 + Enum.max(stdevs)
+        %{
+          deviation: deviation,
+          ratings: team_ratings(team_groups),
+          means: team_means(team_groups),
+          stdevs: stdevs,
+          score: score,
+          team_groups: team_groups,
+        }
+      end
+    end)
+    |> Enum.filter(fn x -> x != nil end)
+    # IO.inspect(valid_candidates, label: "valid_candidates")
+    make_list_of_team_combinations(rest_candidates, team_count, teams ++ valid_candidates)
+  end
+
+  defp has_overlapping_members(group1, group2) do
+    group1
+    |> Enum.flat_map(fn group -> group.members end)
+    |> Enum.any?(fn member ->
+      group2
+      |> Enum.flat_map(fn group -> group.members end)
+      |> Enum.any?(fn other_member -> member == other_member end)
+    end)
+  end
+end

--- a/lib/loser_picks.ex
+++ b/lib/loser_picks.ex
@@ -1,0 +1,477 @@
+defmodule Teiserver.Battle.LoserPicksAlgorithm do
+  @moduledoc """
+  The Algorithm at a high level is:
+  1: Dealing with parties
+    - Go through all groups of 2 or more members and combine their ratings to create one rating for the group
+    - If the group can be paired against a group of equal strength or if any of the remaining solo players can be combined to form a group of sufficiently equal strength, the original group remains intact
+    - Any groups that cannot be matched against a suitable group will be broken into solo players and balanced as such
+
+  2: Placing paired groups
+    - Each pairing of groups are iterated through and assigned to opposite teams
+    - The team with the lowest combined rating picks first and selects the highest rated group
+
+  3: Solo players
+    - As long as there are players left to place
+    - Whichever team with the lowest combined rating and is not full picks next
+    - Said team always picks the highest rated group available
+  """
+
+  alias Teiserver.Account
+  import Teiserver.Battle.BalanceUtil
+  import Central.Helpers.NumberHelper, only: [round: 2]
+
+  @type expanded_group :: BalanceUtils.expanded_group
+  @type expanded_group_or_pair :: BalanceUtils.expanded_group_or_pair
+
+  # We return a list of groups, a list of solo players and logs generated in the process
+  # the purpose of this function is to go through the groups, work out which ones we can keep as
+  # groups and with the ones we can't, break them up and add them back into the pool of solo
+  # players for other groups
+  @spec matchup_groups([expanded_group()], [expanded_group()], list()) ::
+          {[expanded_group()], [expanded_group()], [String.t()]}
+  defp matchup_groups([], solo_players, _opts), do: {[], solo_players, []}
+
+  defp matchup_groups(groups, solo_players, opts) do
+    # First we want to re-sort these groups, we want to have the ones with the highest standard
+    # deviation looked at first, they are the least likely to be able to be matched but most likely to
+    # help match others
+    groups =
+      groups
+      |> Enum.sort_by(
+        fn group ->
+          {group.count, Statistics.stdev(group.ratings)}
+        end,
+        &<=/2
+      )
+
+    do_matchup_groups(groups ++ solo_players, [], [], opts)
+  end
+
+  # First argument is a list of groups (size 1 included) that need to be paired
+  # the second argument is a list of the logs built up by the function
+  # thirdly is a list of already paired up groups (so can't be paired up further)
+  # fourth is the opts list
+  # the function returns a tuple of
+  # 1: paired groups
+  # 2: non-paired groups
+  # 3: logs
+  @spec do_matchup_groups([expanded_group()], [String.t()], [expanded_group()], list()) ::
+          {[expanded_group()], [expanded_group()], [String.t()]}
+  # No groups, no logs
+  defp do_matchup_groups([], [], previous_paired_groups, _opts) do
+    {previous_paired_groups, [], []}
+  end
+
+  # No remaining groups but have some logs
+  defp do_matchup_groups([], logs, previous_paired_groups, _opts) do
+    {previous_paired_groups, [], logs ++ ["End of pairing"]}
+  end
+
+  # This matches when the next group is a size 1, we no longer need to pair up
+  defp do_matchup_groups(
+         [%{count: 1} | _] = remaining_players,
+         logs,
+         previous_paired_groups,
+         _opts
+       ) do
+    {previous_paired_groups, remaining_players, logs ++ ["End of pairing"]}
+  end
+
+  # Main function clause
+  defp do_matchup_groups([group | remaining_groups], logs, previous_paired_groups, opts) do
+    group_mean = Enum.sum(group.ratings) / Enum.count(group.ratings)
+    group_stddev = Statistics.stdev(group.ratings)
+
+    {_remaining_solo, found_groups} =
+      1..(opts[:team_count] - 1)
+      |> Enum.reduce({remaining_groups, []}, fn _, {groups_to_search, results} ->
+        result = find_comparable_group(group, groups_to_search, opts)
+
+        new_groups_to_search =
+          case result do
+            :no_possible_combinations ->
+              []
+
+            :no_possible_players ->
+              []
+
+            %{members: found_members} ->
+              groups_to_search
+              |> Enum.reject(fn %{members: members} ->
+                members
+                |> Enum.any?(fn userid -> Enum.member?(found_members, userid) end)
+              end)
+          end
+
+        {new_groups_to_search, [result | results]}
+      end)
+
+    case hd(found_groups) do
+      :no_possible_combinations ->
+        extra_solos =
+          Enum.zip(group.members, group.ratings)
+          |> Enum.map(fn {userid, rating} ->
+            %{
+              count: 1,
+              group_rating: rating,
+              members: [userid],
+              ratings: [rating]
+            }
+          end)
+
+        names =
+          group.members
+          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+
+        pairing_logs = [
+          "Unable to find a combination match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
+        ]
+
+        do_matchup_groups(
+          remaining_groups ++ extra_solos,
+          logs ++ pairing_logs,
+          previous_paired_groups,
+          opts
+        )
+
+      :no_possible_players ->
+        extra_solos =
+          Enum.zip(group.members, group.ratings)
+          |> Enum.map(fn {userid, rating} ->
+            %{
+              count: 1,
+              group_rating: rating,
+              members: [userid],
+              ratings: [rating]
+            }
+          end)
+
+        names =
+          group.members
+          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+
+        pairing_logs = [
+          "Unable to find a player match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
+        ]
+
+        do_matchup_groups(
+          remaining_groups ++ extra_solos,
+          logs ++ pairing_logs,
+          previous_paired_groups,
+          opts
+        )
+
+      _ ->
+        # Calculate remaining solo players
+        combined_member_ids =
+          found_groups
+          |> Enum.map(fn g -> g.members end)
+          |> List.flatten()
+
+        remaining_groups =
+          remaining_groups
+          |> Enum.reject(fn %{members: members} ->
+            members
+            |> Enum.any?(fn userid -> Enum.member?(combined_member_ids, userid) end)
+          end)
+
+        # Generate log lines, using fgroup so it doesn't clash with group used
+        # earlier
+        grouped_logs =
+          [group | found_groups]
+          |> Enum.map(fn fgroup ->
+            fgroup_name =
+              fgroup.members
+              |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+
+            fgroup_mean = Enum.sum(fgroup.ratings) / Enum.count(fgroup.ratings)
+            fgroup_stddev = Statistics.stdev(fgroup.ratings)
+
+            [
+              "> Grouped: #{fgroup_name}",
+              "--- Rating sum: #{fgroup.group_rating |> round(2)}",
+              "--- Rating Mean: #{fgroup_mean |> round(2)}",
+              "--- Rating Stddev: #{fgroup_stddev |> round(2)}"
+            ]
+          end)
+          |> List.flatten()
+
+        logs = ["Group matching" | logs]
+
+        # Now order the groups by rating so we can pick in the right order
+        found_groups =
+          [group | found_groups]
+          |> Enum.sort_by(fn fg -> fg.group_rating end, &>=/2)
+
+        do_matchup_groups(
+          remaining_groups,
+          logs ++ grouped_logs,
+          [found_groups | previous_paired_groups],
+          opts
+        )
+    end
+  end
+
+  @doc """
+  Each round the team with the lowest score picks, if a team has the maximum number of players
+  they are not allowed to continue picking.
+
+  groups is a list of tuples: {members, rating, member_count}
+  """
+  @spec loser_picks([expanded_group_or_pair()], number(), list()) :: {map(), list()}
+  def loser_picks(expanded_groups, team_count, opts) do
+    teams =
+      Range.new(1, team_count)
+      |> Map.new(fn i ->
+        {i, []}
+      end)
+
+    # Now we have a list of groups, we need to work out which groups we're going to keep
+    # we want to create partner groups but we're only going to do this in a 2 team game
+    # because in a team ffa it'll be very problematic
+    solo_players =
+      expanded_groups
+      |> Enum.filter(fn %{count: count} -> count == 1 end)
+
+    groups =
+      expanded_groups
+      |> Enum.filter(fn %{count: count} -> count > 1 end)
+
+    {group_pairs, solo_players, group_logs} =
+      matchup_groups(groups, solo_players, opts ++ [team_count: team_count])
+
+    # We now need to sort the solo players by rating
+    solo_players =
+      solo_players
+      |> Enum.sort_by(fn %{group_rating: rating} -> rating end, &>=/2)
+
+    groups = group_pairs ++ solo_players
+
+    total_members =
+      groups
+      |> Enum.map(fn
+        {%{count: count1}, %{count: count2}} ->
+          count1 + count2
+
+        %{count: count} ->
+          count
+
+        group_list ->
+          group_list
+          |> Enum.map(fn g -> g.count end)
+          |> Enum.sum()
+      end)
+      |> Enum.sum()
+
+    max_teamsize = (total_members / Enum.count(teams)) |> :math.ceil() |> round()
+
+    # Loser picks returns the member groups in a team as reversed, so we have to un-reverse them.
+    {teams_reversed, logs} = do_loser_picks(groups, teams, max_teamsize, group_logs, opts)
+
+    teams = Map.new(teams_reversed, fn {team_id, groups} ->
+        {team_id, Enum.reverse(groups)}
+      end)
+
+    {teams, group_logs ++ logs}
+  end
+
+  @spec do_loser_picks([expanded_group()], map(), non_neg_integer(), list(), list()) ::
+          {map(), list()}
+  defp do_loser_picks([], teams, _, logs, _opts), do: {teams, logs}
+
+  defp do_loser_picks([picked | remaining_groups], teams, max_teamsize, logs, opts) do
+    team_skills =
+      teams
+      |> Enum.reject(fn {_team_number, member_groups} ->
+        size = sum_group_membership_size(member_groups)
+        size >= max_teamsize
+      end)
+      |> Enum.map(fn {team_number, member_groups} ->
+        score = sum_group_rating(member_groups)
+
+        {score, team_number}
+      end)
+      |> Enum.sort()
+
+    case picked do
+      # Single player
+      %{count: 1} ->
+        current_team =
+          if opts[:shuffle_first_pick] do
+            # Filter out any team with a higher rating than the first
+            low_rating = hd(team_skills) |> elem(0)
+
+            team_skills
+            |> Enum.reject(fn {rating, _id} -> rating > low_rating end)
+            |> Enum.shuffle()
+            |> hd
+            |> elem(1)
+          else
+            hd(team_skills)
+            |> elem(1)
+          end
+
+        new_team = [picked | teams[current_team]]
+        new_team_map = Map.put(teams, current_team, new_team)
+
+        names =
+          picked.members
+          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+
+        new_total = (hd(team_skills) |> elem(0)) + picked.group_rating
+
+        new_logs =
+          logs ++
+            [
+              "Picked #{names} for team #{current_team}, adding #{round(picked.group_rating, 2)} points for new total of #{round(new_total, 2)}"
+            ]
+
+        do_loser_picks(remaining_groups, new_team_map, max_teamsize, new_logs, opts)
+
+      # Groups, so we just merge a bunch of them into teams
+      groups ->
+        # Generate new team map
+        new_team_map =
+          team_skills
+          |> Enum.zip(groups)
+          |> Map.new(fn {{_points, team_number}, group} ->
+            team = teams[team_number] || []
+            {team_number, [group | team]}
+          end)
+
+        # Generate logs
+        extra_logs =
+          team_skills
+          |> Enum.zip(groups)
+          |> Enum.map(fn {{points, team_number}, group} ->
+            names =
+              group.members
+              |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+
+            new_team_total = points + group.group_rating
+
+            "Group picked #{names} for team #{team_number}, adding #{round(group.group_rating, 2)} points for new total of #{round(new_team_total, 2)}"
+          end)
+
+        new_logs = logs ++ extra_logs
+
+        do_loser_picks(remaining_groups, new_team_map, max_teamsize, new_logs, opts)
+    end
+  end
+
+
+  # Stage one, filter out players notably better/worse than the party
+  @spec find_comparable_group(expanded_group(), [expanded_group()], list()) ::
+          :no_possible_players | :no_possible_combinations | expanded_group()
+  defp find_comparable_group(group, solo_players, opts) do
+    rating_lower_bound =
+      Enum.min(group.ratings) - (opts[:rating_lower_boundary] || defaults().rating_lower_boundary)
+
+    rating_upper_bound =
+      Enum.max(group.ratings) + (opts[:rating_upper_boundary] || defaults().rating_upper_boundary)
+
+    possible_players =
+      solo_players
+      |> Enum.filter(fn solo ->
+        solo.group_rating > rating_lower_bound or solo.group_rating < rating_upper_bound
+      end)
+
+    if Enum.count(possible_players) < group.count do
+      :no_possible_players
+    else
+      filter_down_possibles(group, possible_players, opts)
+    end
+  end
+
+
+  # Now we've trimmed our playerlist a bit lets check out the different combinations
+  @spec filter_down_possibles(expanded_group(), [expanded_group()], list()) ::
+          :no_possible_combinations | expanded_group()
+  defp filter_down_possibles(group, possible_players, opts) do
+    group_mean = Enum.sum(group.ratings) / Enum.count(group.ratings)
+    group_stddev = Statistics.stdev(group.ratings)
+
+    sorted_possible_players =
+      possible_players
+      |> Enum.sort_by(fn g -> Enum.count(g.members) end, &>=/2)
+
+    all_combinations =
+      make_combinations(group.count, sorted_possible_players)
+
+      # Filter out bad data (parties can cause bad group sizes)
+      |> Stream.filter(fn members ->
+        total_count =
+          members
+          |> Enum.map(fn g -> g.count end)
+          |> Enum.sum()
+
+        cond do
+          total_count > group.count -> false
+          true -> true
+        end
+      end)
+
+      # This part we are getting the relevant stat info to filter on
+      |> Stream.map(fn members ->
+        member_ratings = Enum.map(members, fn %{group_rating: group_rating} -> group_rating end)
+
+        members_mean = Enum.sum(member_ratings) / group.count
+        members_stddev = Statistics.stdev(member_ratings)
+
+        mean_diff = abs(group_mean - members_mean)
+        stddev_diff = abs(group_stddev - members_stddev)
+
+        {members, mean_diff, stddev_diff}
+      end)
+
+      # We now filter on differences in mean and stddev
+      |> Stream.filter(fn {_members, mean_diff, stddev_diff} ->
+        cond do
+          mean_diff > (opts[:mean_diff_max] || defaults().mean_diff_max) -> false
+          stddev_diff > (opts[:stddev_diff_max] || defaults().stddev_diff_max) -> false
+          true -> true
+        end
+      end)
+
+      # Finally we sort
+      |> Enum.sort_by(
+        fn
+          {_members, mean_diff, stddev_diff} -> {mean_diff * stddev_diff, mean_diff, stddev_diff}
+        end,
+        &<=/2
+      )
+
+    case all_combinations do
+      [] ->
+        :no_possible_combinations
+
+      _ ->
+        {selected_group, _, _} = hd(all_combinations)
+
+        # Now turn a list of groups into one group
+        selected_group
+        |> Enum.reduce(%{members: [], ratings: [], count: 0, group_rating: 0}, fn solo, acc ->
+          %{
+            members: acc.members ++ solo.members,
+            ratings: acc.ratings ++ solo.ratings,
+            count: acc.count + solo.count,
+            group_rating: acc.group_rating + solo.group_rating
+          }
+        end)
+    end
+  end
+
+  # First argument is the size of each combination
+  # Second is the list of items to make a combination from
+  @spec make_combinations(integer(), list) :: [list]
+  defp make_combinations(0, _), do: [[]]
+  defp make_combinations(_, []), do: []
+
+  defp make_combinations(n, [x | xs]) do
+    if n < 0 do
+      [[]]
+    else
+      for(y <- make_combinations(n - x.count, xs), do: [x | y]) ++ make_combinations(n, xs)
+    end
+  end
+end

--- a/lib/party_preserver.ex
+++ b/lib/party_preserver.ex
@@ -7,38 +7,45 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
   @type team_map :: BalanceUtils.team_map
   @type group_list :: [expanded_group_or_pair()]
 
+  def acceptable_teams(teams) do
+    max_team_rating_difference(teams) < 5
+  end
+
   def party_preserver([], _team_count, _opts) do
     {[], []}
   end
 
   @spec party_preserver(group_list(), number(), list()) :: {team_map(), list()}
-  def party_preserver(expanded_groups, team_count, _opts) do
-    expanded_groups
+  def party_preserver(expanded_groups, team_count) do party_preserver(expanded_groups, team_count, []) end
+  def party_preserver(expanded_groups, team_count, log) do
+    {teams, log} = expanded_groups
     |> sort_groups_by_rating()
-    |> IO.inspect(label: "Sorted by rating")
-    |> place_groups_to_smallest_teams(make_empty_teams(team_count), [])
-    |> IO.inspect(label: "Placed groups")
-    |> start_switch_best_rating_diffs()
-    |> IO.inspect(label: "Switched all groups, exiting")
-  end
+    |> IO.inspect(label: "Sorted by rating", charlists: :as_lists)
+    |> place_groups_to_smallest_teams(make_empty_teams(team_count), log)
+    |> IO.inspect(label: "Placed groups", charlists: :as_lists)
+    |> switch_best_rating_diffs()
+    |> IO.inspect(label: "Switched all groups, exiting", charlists: :as_lists)
 
-  @spec start_switch_best_rating_diffs({team_map(), list()}) :: {team_map(), list()}
-  defp start_switch_best_rating_diffs({teams, log}) do
-    switch_best_rating_diffs(teams, log)
+    parties_left = count_parties_in_teams(teams)
+
+    if acceptable_teams(teams) or parties_left <= 0 do
+      {teams, log}
+    else
+      party_preserver(
+        teams_to_groups_without_largest_party(teams),
+        team_count,
+        log ++ ["Unacceptable rating difference of #{max_team_rating_difference(teams)} with current parties, retrying without largest party"])
+    end
   end
 
   # End if the teams are even or if we've switched too many times
-  @spec switch_best_rating_diffs(team_map(), non_neg_integer(), list()) :: {team_map(), list()}
-  defp switch_best_rating_diffs(teams, log) do switch_best_rating_diffs(teams, log, 0) end
-  defp switch_best_rating_diffs(teams, log, i) when i >= @max_switches do
-    {teams, log}
-  end
-
-  defp switch_best_rating_diffs(teams, log, i) when i < @max_switches do
+  @spec switch_best_rating_diffs({team_map(), list()}) :: {team_map(), list()}
+  defp switch_best_rating_diffs({teams, log}) do
     team_rating_diff = max_team_rating_difference(teams)
-    IO.inspect(teams, label: "Team rating diff #{team_rating_diff}")
-    if team_rating_diff < 2 do
-      {teams, log ++ ["Found a good balance of #{team_rating_diff} after #{i} switches"]}
+    IO.inspect(teams, label: "Team rating diff #{team_rating_diff}", charlists: :as_lists)
+
+    if team_rating_diff == 0 do
+      {teams, log ++ ["Teams already balanced"]}
     else
       # Since switching two groups will lower one team and raise the other,
       # We aim to find a pair that has a rating difference of half the total
@@ -46,38 +53,58 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
 
       # Find the best pair of groups to switch between the lowest ranked team
       # and highest ranked team
-      %{
-        highest_team_id: highest_team_id,
-        highest_group_index: highest_group_index,
-        lowest_team_id: lowest_team_id,
-        lowest_group_index: lowest_group_index,
-        rating_diff: rating_diff,
-        best_diff: best_diff
-      } = find_best_pair_to_switch(teams, equalizing_diff)
-
-      IO.inspect(
+      case find_best_pair_to_switch(teams, equalizing_diff) do
+        %{
+          highest_team_id: nil,
+          highest_team_combo: [],
+          lowest_team_id: nil,
+          lowest_team_combo: [],
+          best_diff: :infinity
+        } ->
+          # No pair found, so we can't switch any more
+          {teams, log ++ ["No good switch options found."]}
         %{
           highest_team_id: highest_team_id,
-          highest_group_index: highest_group_index,
+          highest_team_combo: highest_team_combo,
+          lowest_team_combo: lowest_team_combo,
           lowest_team_id: lowest_team_id,
-          lowest_group_index: lowest_group_index,
-          rating_diff: rating_diff,
-          best_diff: best_diff,
-          teams: teams
-        },
-        label: "Best pair to switch")
+          combo_switch_diff: combo_switch_diff,
+          best_diff: best_diff
+        } ->
+          lowest_combo_indices = lowest_team_combo
+            |> Enum.map(fn {_g, i} -> to_string(i) end)
+            |> Enum.join(", ")
 
-      # Switch the best pair
-      switch_best_rating_diffs(
-        switch_group_pair_between_teams(
-          teams,
-          highest_team_id,
-          highest_group_index,
-          lowest_team_id,
-          lowest_group_index
-        ),
-        log ++ ["Switched group #{highest_group_index} from team #{highest_team_id} with group #{lowest_group_index} from team #{lowest_team_id}"],
-        i + 1)
+          highest_combo_indices = highest_team_combo
+            |> Enum.map(fn {_g, i} -> to_string(i) end)
+            |> Enum.join(", ")
+
+          # Found a pair, so switch them
+          IO.inspect(
+            %{
+              highest_team_id: highest_team_id,
+              highest_team_combo: highest_team_combo,
+              lowest_team_id: lowest_team_id,
+              lowest_team_combo: lowest_team_combo,
+              combo_switch_diff: combo_switch_diff,
+              best_diff: best_diff,
+              teams: teams,
+              highest_combo_indices: highest_combo_indices,
+              lowest_combo_indices: lowest_combo_indices,
+            },
+            label: "Best pair to switch",
+            charlists: :as_lists)
+
+          # Switch the best pair
+          {switch_group_combos_between_teams(
+            teams,
+            highest_team_id,
+            highest_team_combo,
+            lowest_team_id,
+            lowest_team_combo
+          ),
+          log ++ ["Switched groups #{highest_combo_indices} from team #{highest_team_id} with groups #{lowest_combo_indices} from team #{lowest_team_id}"]}
+      end
     end
   end
 
@@ -88,40 +115,82 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
     {{lowest_team_id, rating_l}, {highest_team_id, rating_h}} = lowest_highest_rated_teams(teams)
     highest_team_groups = teams[highest_team_id]
     lowest_team_groups = teams[lowest_team_id]
-    IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest: #{lowest_team_id}, #{rating_l}")
+    IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest team #{lowest_team_id}: #{rating_l}. Equalizing diff: #{equalizing_diff}", label: "Finding best pair to switch")
+
+    biggest_group_size = highest_team_groups
+      |> Enum.map(fn group -> group.count end)
+      |> Enum.max()
+
+    highest_team_groups_combos = make_group_combinations(
+      highest_team_groups,
+      biggest_group_size,
+      true)
 
     # Find the pair of groups that are closest to the equalizing_diff
     Enum.reduce(
-      Enum.with_index(highest_team_groups),
+      highest_team_groups_combos,
       %{
         highest_team_id: nil,
-        highest_group_index: nil,
+        highest_team_combo: [],
         lowest_team_id: nil,
-        lowest_group_index: nil,
+        lowest_team_combo: [],
         best_diff: :infinity
       },
-      fn {highest_group, highest_group_index}, best_pair ->
+      fn highest_team_combo, best_pair ->
+        # IO.inspect(highest_team_combo, label: "Highest team group combo", charlists: :as_lists)
+        highest_team_combo_count = Enum.reduce(highest_team_combo, 0,
+          fn {group, _i}, acc -> acc + group.count end)
+        highest_combo_rating = Enum.reduce(highest_team_combo, 0,
+          fn {group, _i}, acc -> acc + group.group_rating end)
+
+        # make matching groups that can be switched with. In this format:
+        # [
+        #  [{group1, 1}, {group2, 2}, {group3, 3}],
+        #  [{group1, 2}, {group4, 4}], # group 4 has 2 members
+        #  [{group2, 2}, {group3, 3}, {group5, 5}],
+        #  ...etc for all combinations of groups with the same number of members
+        # ]
+        lowest_team_groups_combos = make_group_combinations(
+          lowest_team_groups,
+          highest_team_combo_count)
+
         Enum.reduce(
-          Enum.with_index(lowest_team_groups),
+          lowest_team_groups_combos,
           best_pair,
-          fn {lowest_group, lowest_group_index}, best_pair_inner ->
-            if highest_group.count != lowest_group.count do
+          fn combo, best_pair_inner ->
+            %{best_diff: best_diff} = best_pair_inner
+
+            combo_members = Enum.reduce(combo, 0,
+              fn {group, _i}, acc -> acc + group.count end)
+            combo_rating = Enum.reduce(combo, 0,
+              fn {group, _i}, acc -> acc + group.group_rating end)
+
+            if highest_team_combo_count != combo_members do
               # The groups are not the same size, so we can't switch them
               best_pair_inner
             else
-              %{best_diff: best_diff} = best_pair_inner
+              combo_switch_diff = highest_combo_rating - combo_rating
+              # diff_from_equalizing = combo_switch_diff - equalizing_diff
+              diff_from_equalizing = abs(combo_switch_diff - equalizing_diff)
 
-              rating_diff = highest_group.group_rating - lowest_group.group_rating
-              pair_equalizing_diff = abs(rating_diff - equalizing_diff)
+              # IO.inspect(%{
+              #   combo: combo,
+              #   highest_team_combo: highest_team_combo,
+              #   combo_members: combo_members,
+              #   combo_rating: combo_rating,
+              #   combo_switch_diff: combo_switch_diff,
+              #   diff_from_equalizing: diff_from_equalizing,
+              #   best_diff: best_diff
+              # }, label: "matchup", charlists: :as_lists)
 
-              if pair_equalizing_diff < best_diff do
+              if diff_from_equalizing < best_diff do
                 %{
                   highest_team_id: highest_team_id,
-                  highest_group_index: highest_group_index,
+                  highest_team_combo: highest_team_combo,
                   lowest_team_id: lowest_team_id,
-                  lowest_group_index: lowest_group_index,
-                  best_diff: pair_equalizing_diff,
-                  rating_diff: rating_diff
+                  lowest_team_combo: combo,
+                  best_diff: diff_from_equalizing,
+                  combo_switch_diff: combo_switch_diff
                 }
               else
                 best_pair_inner
@@ -138,7 +207,7 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
       0 -> {teams, log}
       1 -> {teams, log}
       _ ->
-        IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party")
+        IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party", charlists: :as_lists)
         # Break up the biggest party (there has to be a party) that obstructs
         # making equal teams and restart grouping, which now should be easier to get even.
         place_groups_to_smallest_teams(
@@ -175,8 +244,8 @@ defmodule Teiserver.Battle.PartyPreserverAlgorithm do
   end
 
   defp break_up_first_party([group | rest_groups]) do
-    rest_groups ++ Enum.map(group.members,
-      fn member -> %{count: 1, group_rating: member, members: [member]} end)
+    rest_groups ++ Enum.map(Enum.with_index(group.members),
+      fn {member_id, i} -> %{count: 1, group_rating: Enum.at(group.ratings, i), ratings: Enum.at(group.ratings, i), members: [member_id]} end)
   end
 
   @spec add_group_to_team(team_map(), expanded_group_or_pair(), atom()) :: team_map()

--- a/lib/party_preserver.ex
+++ b/lib/party_preserver.ex
@@ -1,0 +1,198 @@
+defmodule Teiserver.Battle.PartyPreserverAlgorithm do
+  import Teiserver.Battle.BalanceUtil
+
+  @max_switches 3
+
+  @type expanded_group_or_pair :: BalanceUtils.expanded_group_or_pair
+  @type team_map :: BalanceUtils.team_map
+  @type group_list :: [expanded_group_or_pair()]
+
+  def party_preserver([], _team_count, _opts) do
+    {[], []}
+  end
+
+  @spec party_preserver(group_list(), number(), list()) :: {team_map(), list()}
+  def party_preserver(expanded_groups, team_count, _opts) do
+    expanded_groups
+    |> sort_groups_by_rating()
+    |> IO.inspect(label: "Sorted by rating")
+    |> place_groups_to_smallest_teams(make_empty_teams(team_count), [])
+    |> IO.inspect(label: "Placed groups")
+    |> start_switch_best_rating_diffs()
+    |> IO.inspect(label: "Switched all groups, exiting")
+  end
+
+  @spec start_switch_best_rating_diffs({team_map(), list()}) :: {team_map(), list()}
+  defp start_switch_best_rating_diffs({teams, log}) do
+    switch_best_rating_diffs(teams, log)
+  end
+
+  # End if the teams are even or if we've switched too many times
+  @spec switch_best_rating_diffs(team_map(), non_neg_integer(), list()) :: {team_map(), list()}
+  defp switch_best_rating_diffs(teams, log) do switch_best_rating_diffs(teams, log, 0) end
+  defp switch_best_rating_diffs(teams, log, i) when i >= @max_switches do
+    {teams, log}
+  end
+
+  defp switch_best_rating_diffs(teams, log, i) when i < @max_switches do
+    team_rating_diff = max_team_rating_difference(teams)
+    IO.inspect(teams, label: "Team rating diff #{team_rating_diff}")
+    if team_rating_diff < 2 do
+      {teams, log ++ ["Found a good balance of #{team_rating_diff} after #{i} switches"]}
+    else
+      # Since switching two groups will lower one team and raise the other,
+      # We aim to find a pair that has a rating difference of half the total
+      equalizing_diff = team_rating_diff / 2
+
+      # Find the best pair of groups to switch between the lowest ranked team
+      # and highest ranked team
+      %{
+        highest_team_id: highest_team_id,
+        highest_group_index: highest_group_index,
+        lowest_team_id: lowest_team_id,
+        lowest_group_index: lowest_group_index,
+        rating_diff: rating_diff,
+        best_diff: best_diff
+      } = find_best_pair_to_switch(teams, equalizing_diff)
+
+      IO.inspect(
+        %{
+          highest_team_id: highest_team_id,
+          highest_group_index: highest_group_index,
+          lowest_team_id: lowest_team_id,
+          lowest_group_index: lowest_group_index,
+          rating_diff: rating_diff,
+          best_diff: best_diff,
+          teams: teams
+        },
+        label: "Best pair to switch")
+
+      # Switch the best pair
+      switch_best_rating_diffs(
+        switch_group_pair_between_teams(
+          teams,
+          highest_team_id,
+          highest_group_index,
+          lowest_team_id,
+          lowest_group_index
+        ),
+        log ++ ["Switched group #{highest_group_index} from team #{highest_team_id} with group #{lowest_group_index} from team #{lowest_team_id}"],
+        i + 1)
+    end
+  end
+
+  # Find a pair of groups from the lowest ranked team and highest ranked team
+  # that have a rating difference close to equalizing_diff
+  @spec find_best_pair_to_switch(team_map(), non_neg_integer()) :: map()
+  defp find_best_pair_to_switch(teams, equalizing_diff) do
+    {{lowest_team_id, rating_l}, {highest_team_id, rating_h}} = lowest_highest_rated_teams(teams)
+    highest_team_groups = teams[highest_team_id]
+    lowest_team_groups = teams[lowest_team_id]
+    IO.inspect("Highest team #{highest_team_id}: #{rating_h}, lowest: #{lowest_team_id}, #{rating_l}")
+
+    # Find the pair of groups that are closest to the equalizing_diff
+    Enum.reduce(
+      Enum.with_index(highest_team_groups),
+      %{
+        highest_team_id: nil,
+        highest_group_index: nil,
+        lowest_team_id: nil,
+        lowest_group_index: nil,
+        best_diff: :infinity
+      },
+      fn {highest_group, highest_group_index}, best_pair ->
+        Enum.reduce(
+          Enum.with_index(lowest_team_groups),
+          best_pair,
+          fn {lowest_group, lowest_group_index}, best_pair_inner ->
+            if highest_group.count != lowest_group.count do
+              # The groups are not the same size, so we can't switch them
+              best_pair_inner
+            else
+              %{best_diff: best_diff} = best_pair_inner
+
+              rating_diff = highest_group.group_rating - lowest_group.group_rating
+              pair_equalizing_diff = abs(rating_diff - equalizing_diff)
+
+              if pair_equalizing_diff < best_diff do
+                %{
+                  highest_team_id: highest_team_id,
+                  highest_group_index: highest_group_index,
+                  lowest_team_id: lowest_team_id,
+                  lowest_group_index: lowest_group_index,
+                  best_diff: pair_equalizing_diff,
+                  rating_diff: rating_diff
+                }
+              else
+                best_pair_inner
+              end
+            end
+          end)
+      end)
+  end
+
+  @spec place_groups_to_smallest_teams(group_list(), team_map(), list()) :: {team_map(), list()}
+  defp place_groups_to_smallest_teams([], teams, log) do
+    team_member_diff = max_team_member_count_difference(teams)
+    case team_member_diff do
+      0 -> {teams, log}
+      1 -> {teams, log}
+      _ ->
+        IO.inspect(teams, label: "Teams are not even (#{team_member_diff}), breaking up largest party")
+        # Break up the biggest party (there has to be a party) that obstructs
+        # making equal teams and restart grouping, which now should be easier to get even.
+        place_groups_to_smallest_teams(
+          teams_to_groups_without_largest_party(teams),
+          make_empty_teams(map_size(teams)),
+          log ++ ["Teams are not even, breaking up largest party"]
+        )
+    end
+  end
+
+  defp place_groups_to_smallest_teams([next_group | rest_groups], teams, log) do
+    team_key = find_smallest_team_key(teams);
+    place_groups_to_smallest_teams(
+      rest_groups,
+      add_group_to_team(teams, next_group, team_key),
+      log ++ ["Added #{next_group.count} members with total rating of #{next_group.group_rating} to team #{team_key}"])
+  end
+
+  @spec teams_to_groups_without_largest_party(map()) :: group_list()
+  defp teams_to_groups_without_largest_party(teams) do
+    teams
+    # Return to the list of groups
+    |> unwind_teams_to_groups()
+    # Sort by party size
+    |> sort_groups_by_count()
+    # Break up the first and largest party
+    |> break_up_first_party()
+    # Sort again by rating
+    |> sort_groups_by_rating()
+  end
+
+  defp break_up_first_party([]) do
+    []
+  end
+
+  defp break_up_first_party([group | rest_groups]) do
+    rest_groups ++ Enum.map(group.members,
+      fn member -> %{count: 1, group_rating: member, members: [member]} end)
+  end
+
+  @spec add_group_to_team(team_map(), expanded_group_or_pair(), atom()) :: team_map()
+  defp add_group_to_team(teams, group, team_key) do
+    Map.update!(teams, team_key, fn members -> members ++ [group] end)
+  end
+
+  @spec find_smallest_team_key(team_map()) :: atom()
+  defp find_smallest_team_key(teams) do
+    Enum.min_by(
+      teams,
+      fn {_k, team_groups} -> case length(team_groups) do
+        0 -> 0
+        _ -> sum_group_membership_size(team_groups)
+      end
+    end)
+    |> elem(0)
+  end
+end

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -1,5 +1,5 @@
 defmodule Teiserver.Battle.BalanceLibTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias Teiserver.Battle.BalanceLib
 
   test "loser picks simple users" do
@@ -45,7 +45,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              deviation: 0,
              means: %{1 => 6.5, 2 => 6.5},
-             stdevs: %{1 => 1.5, 2 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 0.5},
+             parties: {0, 0}
            }
   end
 
@@ -96,7 +97,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              deviation: 13,
              means: %{1 => 8.0, 2 => 7.0, 3 => 6.0, 4 => 5.0},
-             stdevs: %{1 => 0.0, 2 => 0.0, 3 => 0.0, 4 => 0.0}
+             stdevs: %{1 => 0.0, 2 => 0.0, 3 => 0.0, 4 => 0.0},
+             parties: {0, 0}
            }
   end
 
@@ -153,7 +155,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              deviation: 0,
              means: %{1 => 7.5, 2 => 7.0, 3 => 7.5},
-             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5},
+             parties: {0, 0}
            }
   end
 
@@ -201,7 +204,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              deviation: 0,
              means: %{1 => 6.5, 2 => 6.5},
-             stdevs: %{1 => 1.5, 2 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 0.5},
+             parties: {1, 1}
            }
   end
 
@@ -268,7 +272,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 20.125, 2 => 20.5},
-             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312}
+             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312},
+             parties: {2, 3}
            }
   end
 
@@ -327,11 +332,12 @@ defmodule Teiserver.Battle.BalanceLibTest do
              team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 23.0, 2 => 23.0},
-             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736},
+             parties: {0, 1}
            }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "loser_picks: two parties" do
     result =
       BalanceLib.create_balance(
@@ -386,7 +392,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046},
+             parties: {2, 2}
            }
 
     result2 =
@@ -445,7 +452,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.0312195418814, 2 => 15.074295174236173}
+             stdevs: %{1 => 16.0312195418814, 2 => 15.074295174236173},
+             parties: {2, 2}
            }
   end
 
@@ -463,50 +471,20 @@ defmodule Teiserver.Battle.BalanceLibTest do
         3,
         algorithm: :cheeky_switcher
       )
-      |> Map.drop([:logs, :time_taken])
+      |> Map.drop([:logs, :time_taken, :team_groups, :team_players])
 
     assert result == %{
-             team_groups: %{
-               1 => [
-                 %{count: 1, group_rating: 9, members: [5], ratings: [9]},
-                 %{count: 1, group_rating: 6, members: [2], ratings: [6]}
-               ],
-               2 => [
-                 %{count: 1, group_rating: 9, members: [6], ratings: [9]},
-                 %{count: 1, group_rating: 5, members: [1], ratings: [5]}
-               ],
-               3 => [
-                 %{count: 1, group_rating: 8, members: [4], ratings: [8]},
-                 %{count: 1, group_rating: 7, members: [3], ratings: [7]}
-               ]
-             },
-             team_players: %{
-               1 => [5, 2],
-               2 => [6, 1],
-               3 => [4, 3]
-             },
-             ratings: %{
-               1 => 15,
-               2 => 14,
-               3 => 15
-             },
-             captains: %{
-               1 => 5,
-               2 => 6,
-               3 => 4
-             },
-             team_sizes: %{
-               1 => 2,
-               2 => 2,
-               3 => 2
-             },
-             deviation: 0,
-             means: %{1 => 7.5, 2 => 7.0, 3 => 7.5},
-             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5}
-           }
+      captains: %{1 => 4, 2 => 2, 3 => 6},
+      deviation: 0,
+      means: %{1 => 7.5, 2 => 7.5, 3 => 7.0},
+      ratings: %{1 => 15, 2 => 15, 3 => 14},
+      stdevs: %{1 => 0.5, 2 => 1.5, 3 => 2.0},
+      team_sizes: %{1 => 2, 2 => 2, 3 => 2},
+      parties: {0, 0}
+    }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "cheeky_switcher: MasterBel2 case" do
     result =
       BalanceLib.create_balance(
@@ -530,41 +508,18 @@ defmodule Teiserver.Battle.BalanceLibTest do
         algorithm: :cheeky_switcher
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 105, 2 => 106},
-             deviation: 2,
-             ratings: %{1 => 248, 2 => 253},
-             team_groups: %{
-               1 => [
-                 %{count: 2, group_rating: 24.53, members: [101, 102], ratings: [9.39, 15.14]},
-                 %{count: 1, group_rating: 43.69, members: [105], ratings: [43.69]},
-                 %{count: 1, group_rating: 29.56, members: [106], ratings: [29.56]},
-                 %{count: 1, group_rating: 28.27, members: [107], ratings: [28.27]},
-                 %{count: 1, group_rating: 25.34, members: [108], ratings: [25.34]},
-                 %{count: 1, group_rating: 23.45, members: [109], ratings: [23.45]},
-                 %{count: 1, group_rating: 10.27, members: [116], ratings: [10.27]}
-               ],
-               2 => [
-                 %{count: 2, group_rating: 43.9, members: [103, 104], ratings: [28.84, 15.06]},
-                 %{count: 1, group_rating: 21.65, members: [110], ratings: [21.65]},
-                 %{count: 1, group_rating: 21.6, members: [111], ratings: [21.6]},
-                 %{count: 1, group_rating: 18.46, members: [112], ratings: [18.46]},
-                 %{count: 1, group_rating: 17.7, members: [113], ratings: [17.7]},
-                 %{count: 1, group_rating: 16.29, members: [114], ratings: [16.29]},
-                 %{count: 1, group_rating: 16.01, members: [115], ratings: [16.01]}
-               ]
-             },
-             team_players: %{
-               1 => [104, 105, 106, 107, 110, 111, 114, 116],
-               2 => [101, 102, 103, 108, 109, 112, 113, 115]
-             },
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
+             captains: %{1 => :hitman, 2 => :eural},
+              deviation: 0,
+              means: %{1 => 21.2825, 2 => 21.307499999999997},
+              ratings: %{1 => 170.26, 2 => 170.45999999999998},
+              stdevs: %{1 => 9.866508691021357, 2 => 6.440535206797646},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {2, 2}
            }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "loser_picks: MasterBel2 case" do
     result =
       BalanceLib.create_balance(
@@ -588,95 +543,14 @@ defmodule Teiserver.Battle.BalanceLibTest do
         algorithm: :loser_picks
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 105, 2 => 106},
-             deviation: 2,
-             ratings: %{1 => 248, 2 => 253},
-             team_groups: %{
-               1 => [
-                 %{count: 2, group_rating: 24.53, members: [101, 102], ratings: [9.39, 15.14]},
-                 %{count: 1, group_rating: 43.69, members: [105], ratings: [43.69]},
-                 %{count: 1, group_rating: 29.56, members: [106], ratings: [29.56]},
-                 %{count: 1, group_rating: 28.27, members: [107], ratings: [28.27]},
-                 %{count: 1, group_rating: 25.34, members: [108], ratings: [25.34]},
-                 %{count: 1, group_rating: 23.45, members: [109], ratings: [23.45]},
-                 %{count: 1, group_rating: 10.27, members: [116], ratings: [10.27]}
-               ],
-               2 => [
-                 %{count: 2, group_rating: 43.9, members: [103, 104], ratings: [28.84, 15.06]},
-                 %{count: 1, group_rating: 21.65, members: [110], ratings: [21.65]},
-                 %{count: 1, group_rating: 21.6, members: [111], ratings: [21.6]},
-                 %{count: 1, group_rating: 18.46, members: [112], ratings: [18.46]},
-                 %{count: 1, group_rating: 17.7, members: [113], ratings: [17.7]},
-                 %{count: 1, group_rating: 16.29, members: [114], ratings: [16.29]},
-                 %{count: 1, group_rating: 16.01, members: [115], ratings: [16.01]}
-               ]
-             },
-             team_players: %{
-               1 => [104, 105, 106, 107, 110, 111, 114, 116],
-               2 => [101, 102, 103, 108, 109, 112, 113, 115]
-             },
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
-           }
-  end
-
-  # @tag runnable: true
-  test "brute: MasterBel2 case" do
-    result =
-      BalanceLib.create_balance(
-        [
-          %{:hitman => 9.39, :kayme => 15.14},
-          %{:eural => 28.84, :morgan => 15.06},
-          %{:zerpiderp => 43.69},
-          %{:gabb => 29.56},
-          %{:flaka => 28.27},
-          %{:gegx001 => 25.34},
-          %{:lordvenom1 => 23.45},
-          %{:notlobsters => 21.65},
-          %{:trimbil => 21.6},
-          %{:redspatula => 18.46},
-          %{:claaay => 17.7},
-          %{:korbal22 => 16.29},
-          %{:p4r0 => 16.01},
-          %{:amadeuz => 10.27}
-        ],
-        2,
-        algorithm: :brute_force
-      )
-
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 105, 2 => 106},
-             deviation: 2,
-             ratings: %{1 => 248, 2 => 253},
-             team_groups: %{
-               1 => [
-                 %{count: 2, group_rating: 24.53, members: [101, 102], ratings: [9.39, 15.14]},
-                 %{count: 1, group_rating: 43.69, members: [105], ratings: [43.69]},
-                 %{count: 1, group_rating: 29.56, members: [106], ratings: [29.56]},
-                 %{count: 1, group_rating: 28.27, members: [107], ratings: [28.27]},
-                 %{count: 1, group_rating: 25.34, members: [108], ratings: [25.34]},
-                 %{count: 1, group_rating: 23.45, members: [109], ratings: [23.45]},
-                 %{count: 1, group_rating: 10.27, members: [116], ratings: [10.27]}
-               ],
-               2 => [
-                 %{count: 2, group_rating: 43.9, members: [103, 104], ratings: [28.84, 15.06]},
-                 %{count: 1, group_rating: 21.65, members: [110], ratings: [21.65]},
-                 %{count: 1, group_rating: 21.6, members: [111], ratings: [21.6]},
-                 %{count: 1, group_rating: 18.46, members: [112], ratings: [18.46]},
-                 %{count: 1, group_rating: 17.7, members: [113], ratings: [17.7]},
-                 %{count: 1, group_rating: 16.29, members: [114], ratings: [16.29]},
-                 %{count: 1, group_rating: 16.01, members: [115], ratings: [16.01]}
-               ]
-             },
-             team_players: %{
-               1 => [104, 105, 106, 107, 110, 111, 114, 116],
-               2 => [101, 102, 103, 108, 109, 112, 113, 115]
-             },
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
+             captains: %{1 => :gabb, 2 => :eural},
+              deviation: 7,
+              means: %{1 => 20.5125, 2 => 22.077499999999997},
+              ratings: %{1 => 164.1, 2 => 176.61999999999998},
+              stdevs: %{1 => 6.531182415918269, 2 => 9.744118418307528},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {2, 2}
            }
   end
 
@@ -712,42 +586,18 @@ defmodule Teiserver.Battle.BalanceLibTest do
         stddev_diff_max: 5
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 112, 2 => 103},
-             deviation: 2,
-             ratings: %{1 => 161, 2 => 164},
-             team_groups: %{
-               1 => [
-                 %{count: 3, group_rating: 51, members: [112, 113, 114], ratings: [19, 16, 16]},
-                 %{count: 2, group_rating: 22, members: [115, 116], ratings: [14, 8]},
-                 %{count: 1, group_rating: 41, members: [101], ratings: [41]},
-                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
-                 %{count: 1, group_rating: 21, members: [111], ratings: [21]}
-               ],
-               2 => [
-                 %{
-                   count: 3,
-                   group_rating: 50.5,
-                   members: [103, 104, 105],
-                   ratings: [20, 17, 13.5]
-                 },
-                 %{count: 2, group_rating: 22.5, members: [106, 107], ratings: [15, 7.5]},
-                 %{count: 1, group_rating: 35, members: [102], ratings: [35]},
-                 %{count: 1, group_rating: 31, members: [108], ratings: [31]},
-                 %{count: 1, group_rating: 25, members: [110], ratings: [25]}
-               ]
-             },
-             team_players: %{
-               1 => [112, 113, 114, 115, 116, 101, 109, 111],
-               2 => [103, 104, 105, 106, 107, 102, 108, 110]
-             },
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 20.125, 2 => 20.5},
-             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312}
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
+             captains: %{1 => 103, 2 => 101},
+              deviation: 0,
+              means: %{1 => 20.3125, 2 => 20.3125},
+              ratings: %{1 => 162.5, 2 => 162.5},
+              stdevs: %{1 => 5.963102694906403, 2 => 11.227581830029118},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {3, 3}
            }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "cheeky_switcher: smurf party" do
     result =
       BalanceLib.create_balance(
@@ -774,40 +624,18 @@ defmodule Teiserver.Battle.BalanceLibTest do
         algorithm: :cheeky_switcher
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
              captains: %{1 => 101, 2 => 104},
-             deviation: 0,
-             ratings: %{1 => 184, 2 => 184},
-             team_groups: %{
-               1 => [
-                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
-                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
-                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
-                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
-                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
-                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
-                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
-                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
-               ],
-               2 => [
-                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
-                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
-                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
-                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
-                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
-                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
-                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
-                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
-               ]
-             },
-             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 23.0, 2 => 23.0},
-             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+              deviation: 0,
+              means: %{1 => 23.0, 2 => 23.0},
+              ratings: %{1 => 184, 2 => 184},
+              stdevs: %{1 => 13.238202294873727, 2 => 8.0156097709407},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {1, 1}
            }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "cheeky_switcher: stacked groups" do
     result =
       BalanceLib.create_balance(
@@ -826,40 +654,18 @@ defmodule Teiserver.Battle.BalanceLibTest do
         algorithm: :cheeky_switcher
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 101, 2 => 104},
-             deviation: 0,
-             ratings: %{1 => 184, 2 => 184},
-             team_groups: %{
-               1 => [
-                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
-                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
-                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
-                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
-                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
-                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
-                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
-                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
-               ],
-               2 => [
-                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
-                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
-                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
-                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
-                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
-                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
-                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
-                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
-               ]
-             },
-             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 23.0, 2 => 23.0},
-             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
+             captains: %{1 => 110, 2 => 114},
+              deviation: 1,
+              means: %{1 => 20.625, 2 => 20.375},
+              ratings: %{1 => 165, 2 => 163},
+              stdevs: %{1 => 7.8888766627448295, 2 => 9.205127647132331},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {2, 3}
            }
   end
 
-  # @tag runnable: true
+  @tag runnable: false
   test "loser_picks: stacked groups" do
     result =
       BalanceLib.create_balance(
@@ -878,37 +684,83 @@ defmodule Teiserver.Battle.BalanceLibTest do
         algorithm: :loser_picks
       )
 
-    assert Map.drop(result, [:logs, :time_taken]) == %{
-             captains: %{1 => 101, 2 => 104},
-             deviation: 0,
-             ratings: %{1 => 184, 2 => 184},
-             team_groups: %{
-               1 => [
-                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
-                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
-                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
-                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
-                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
-                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
-                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
-                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
-               ],
-               2 => [
-                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
-                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
-                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
-                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
-                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
-                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
-                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
-                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
-               ]
-             },
-             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
-             team_sizes: %{1 => 8, 2 => 8},
-             means: %{1 => 23.0, 2 => 23.0},
-             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
+             captains: %{1 => 108, 2 => 110},
+              deviation: 1,
+              means: %{1 => 20.625, 2 => 20.375},
+              ratings: %{1 => 165, 2 => 163},
+              stdevs: %{1 => 8.802520945729126, 2 => 8.335728822364604},
+              team_sizes: %{1 => 8, 2 => 8},
+              parties: {1, 3}
+
            }
+  end
+
+  @tag runnable: false
+  test "Compare algorithms stacked groups" do
+    groups = [ [11, 10, 10, 35], [25, 21, 19, 16], [15, 14, 8],
+      [34], [29], [28], [27], [26], ]
+    compare_algorithm_results(groups, 2, "stacked groups")
+    compare_algorithm_times(groups, 2, "stacked groups")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms MasterBel2 case" do
+    groups = [ [9.39, 15.14], [28.84, 15.06], [43.69], [29.56], [28.27],
+      [25.34], [23.45], [21.65], [21.6], [18.46], [17.7], [16.29],
+      [16.01], [10.27] ]
+    compare_algorithm_results(groups, 2, "MasterBel2 case")
+    compare_algorithm_times(groups, 2, "MasterBel2 case")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms: team_ffa" do
+    groups = [ [5], [6], [7], [8], [9], [9] ]
+    compare_algorithm_results(groups, 3, "team_ffa")
+    compare_algorithm_times(groups, 3, "team_ffa")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms: smurf party" do
+    groups = [ [51, 10, 10],
+      [35], [34], [29], [28], [27], [26], [25], [21], [19], [16],
+      [15], [14], [8] ]
+    compare_algorithm_results(groups, 2, "smurf party")
+    compare_algorithm_times(groups, 2, "smurf party")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms: odd users" do
+    groups = [ [51], [10], [10], [35], [34], [29], [28], [27], [26],
+      [25], [21], [19], [16], [15], [8] ]
+    compare_algorithm_results(groups, 2, "odd users")
+    compare_algorithm_times(groups, 2, "odd users")
+  end
+
+  @tag runnable: true
+  test "Compare algorithms: Even spread" do
+    groups = [ [24.42], [23.11], [22.72], [21.01], [20.13], [20.81], [19.78],
+      [18.20], [17.10], [16.11], [15.10], [14.08], [13.91], [13.19], [12.1],
+      [11.01], ]
+    compare_algorithm_results(groups, 2, "Even spread")
+    compare_algorithm_times(groups, 2, "Even spread")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms: Even spread - itegers" do
+    groups = [ [24], [23], [22], [21], [20], [20], [19], [18], [17], [16],
+     [15], [14], [13], [13], [12], [11] ]
+    compare_algorithm_results(groups, 2, "Even spread - integers")
+    compare_algorithm_times(groups, 2, "Even spread - integers")
+  end
+
+  @tag runnable: false
+  test "Compare algorithms: High low" do
+    groups = [
+      [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
+      [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], ]
+    compare_algorithm_results(groups, 2, "High low")
+    compare_algorithm_times(groups, 2, "High low")
   end
 
   def simple_teams(teams) do
@@ -919,7 +771,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         cond do
           is_list(group.ratings) -> group.ratings
           is_number(group.ratings) -> [group.ratings]
-          true -> raise "Invalid ratings: #{inspect(group.ratings)}"
+          false -> raise "Invalid ratings: #{inspect(group.ratings)}"
         end
       end)
     end)
@@ -944,11 +796,12 @@ defmodule Teiserver.Battle.BalanceLibTest do
 
     preserved_parties_count = length(preserved_parties)
 
-    "Preserved parties: #{preserved_parties_count} / #{original_party_count}"
+    %{:preserved => preserved_parties_count,
+      :original => original_party_count}
   end
 
-  def compare_algorithms(parties, team_count, test_name) do
-    party_map_list = parties
+  def to_party_map_list(parties) do
+    parties
     |> Enum.with_index()
     |> Enum.map(fn {party, index} ->
       party
@@ -958,43 +811,16 @@ defmodule Teiserver.Battle.BalanceLibTest do
       end)
       |> Map.new()
     end)
+  end
 
-    IO.inspect(parties, label: "#{test_name} user list", charlists: :as_lists)
-
-    result_loser_picks =
-      BalanceLib.create_balance(
-        party_map_list,
-        team_count,
-        algorithm: :loser_picks
-      )
-
+  def run_algorithm_and_print_results(party_map_list, parties, team_count, algorithm, test_name) do
     result_cheeky_switcher =
       BalanceLib.create_balance(
         party_map_list,
         team_count,
-        algorithm: :cheeky_switcher
+        algorithm: algorithm
       )
 
-    result_brute_force =
-      BalanceLib.create_balance(
-        party_map_list,
-        team_count,
-        algorithm: :brute_force
-      )
-
-    IO.inspect(%{
-      deviation: result_loser_picks.deviation,
-      ratings: result_loser_picks.ratings,
-      means: result_loser_picks.means,
-      stdevs: result_loser_picks.stdevs,
-      time_taken: result_loser_picks.time_taken,
-      team_groups: simple_teams(result_loser_picks.team_groups),
-      parties: parties_preserved(parties, simple_teams(result_loser_picks.team_groups)),
-      # team_groups_full: result_loser_picks.team_groups,
-      # logs: result_loser_picks.logs
-    }, label: "#{test_name}: loser_picks", charlists: :as_lists)
-
-    IO.inspect(result_cheeky_switcher.logs, label: "#{test_name}: cheeky_switcher logs", charlists: :as_strings)
     IO.inspect(%{
       deviation: result_cheeky_switcher.deviation,
       ratings: result_cheeky_switcher.ratings,
@@ -1004,116 +830,84 @@ defmodule Teiserver.Battle.BalanceLibTest do
       team_groups: simple_teams(result_cheeky_switcher.team_groups),
       parties: parties_preserved(parties, simple_teams(result_cheeky_switcher.team_groups)),
       # team_groups_full: result_cheeky_switcher.team_groups,
-    }, label: "#{test_name}: cheeky_switcher", charlists: :as_lists)
+    }, label: "#{test_name}: #{algorithm}", charlists: :as_lists)
+  end
+
+  def compare_algorithm_results(parties, team_count, test_name) do
+    party_map_list = to_party_map_list(parties)
+
+    IO.inspect(parties, label: "\nCompare timings: #{test_name}", charlists: :as_lists)
+
+    run_algorithm_and_print_results(
+      party_map_list,
+      parties,
+      team_count,
+      :cheeky_switcher,
+      test_name)
+
+    run_algorithm_and_print_results(
+      party_map_list,
+      parties,
+      team_count,
+      :cheeky_switcher_rating,
+      test_name)
+
+    run_algorithm_and_print_results(
+      party_map_list,
+      parties,
+      team_count,
+      :loser_picks,
+      test_name)
+
+    # Commented out because it is slooow, but sometimes useful for debugging
+    # when looking for an optimal result
+    # run_algorithm_and_print_results(party_map_list, team_count, :brute_force, test_name)
+  end
+
+  def compare_algorithm_times(parties, team_count, test_name) do
+    party_map_list = to_party_map_list(parties)
+
+    IO.inspect(parties, label: "\nCompare results: #{test_name}", charlists: :as_lists)
+
+    iterations = 10000
+
+    result_loser_picks_time = 1..iterations
+      |> Enum.map(fn _ ->
+        BalanceLib.create_balance(
+          party_map_list,
+          team_count,
+          algorithm: :loser_picks
+        )
+      end)
+      |> Enum.map(fn result -> result.time_taken end)
+      |> Enum.sum()
+
+    result_cheeky_switcher_time = 1..iterations
+      |> Enum.map(fn _ ->
+        BalanceLib.create_balance(
+          party_map_list,
+          team_count,
+          algorithm: :cheeky_switcher
+        )
+      end)
+      |> Enum.map(fn result -> result.time_taken end)
+      |> Enum.sum()
+
+    result_cheeky_switcher_rating_time = 1..iterations
+      |> Enum.map(fn _ ->
+        BalanceLib.create_balance(
+          party_map_list,
+          team_count,
+          algorithm: :cheeky_switcher_rating
+        )
+      end)
+      |> Enum.map(fn result -> result.time_taken end)
+      |> Enum.sum()
 
     IO.inspect(%{
-      deviation: result_brute_force.deviation,
-      ratings: result_brute_force.ratings,
-      means: result_brute_force.means,
-      stdevs: result_brute_force.stdevs,
-      time_taken: result_brute_force.time_taken,
-      team_groups: simple_teams(result_brute_force.team_groups),
-      parties: parties_preserved(parties, simple_teams(result_brute_force.team_groups)),
-    }, label: "#{test_name}: brute_force", charlists: :as_lists)
-
-    assert result_cheeky_switcher.deviation <= result_loser_picks.deviation
-    assert Enum.sum(Map.values(result_cheeky_switcher.stdevs)) <= Enum.sum(Map.values(result_loser_picks.stdevs))
-    assert result_cheeky_switcher.time_taken <= result_loser_picks.time_taken
-    assert result_cheeky_switcher.time_taken <= result_brute_force.time_taken
-  end
-
-  @tag runnable: true
-  test "Compare algorithms stacked groups" do
-    parties = [
-      [11, 10, 10, 35],
-      [25, 21, 19, 16],
-      [15, 14, 8],
-      [34],
-      [29],
-      [28],
-      [27],
-      [26],
-    ]
-    compare_algorithms(parties, 2, "stacked groups")
-  end
-
-  @tag runnable: true
-  test "Compare algorithms MasterBel2 case" do
-    parties = [
-      [9.39, 15.14],
-      [28.84, 15.06],
-      [43.69],
-      [29.56],
-      [28.27],
-      [25.34],
-      [23.45],
-      [21.65],
-      [21.6],
-      [18.46],
-      [17.7],
-      [16.29],
-      [16.01],
-      [10.27]
-    ]
-    compare_algorithms(parties, 2, "MasterBel2 case")
-  end
-
-  # @tag runnable: true
-  test "Compare algorithms: team_ffa" do
-    parties = [
-      [5],
-      [6],
-      [7],
-      [8],
-      [9],
-      [9]
-    ]
-    compare_algorithms(parties, 3, "team_ffa")
-  end
-
-  @tag runnable: true
-  test "Compare algorithms: smurf party" do
-    parties = [
-       # Our smurf party
-      [51, 10, 10],
-
-      # Other players, a range of ratings
-      [35],
-      [34],
-      [29],
-      [28],
-      [27],
-      [26],
-      [25],
-      [21],
-      [19],
-      [16],
-      [15],
-      [14],
-      [8]
-    ]
-    compare_algorithms(parties, 2, "smurf party")
-  end
-
-  # @tag runnable: true
-  test "Compare algorithms: odd users" do
-    parties = [
-      [51],
-      [10],
-      [10],
-      [35],
-      [34],
-      [29],
-      [28],
-      [27],
-      [26],
-      [25],
-      [21],
-      [19],
-      [16],
-      [15],
-      [8]
-    ]
-    compare_algorithms(parties, 2, "odd users")
+      loser_picks_time: result_loser_picks_time / iterations,
+      cheeky_switcher_time: result_cheeky_switcher_time / iterations,
+      cheeky_switcher_rating_time: result_cheeky_switcher_rating_time / iterations
+    })
   end
 end

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -331,7 +331,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "two parties" do
+  @tag runnable: true
+  test "loser_picks: two parties" do
     result =
       BalanceLib.create_balance(
         [
@@ -448,7 +449,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "team_preserver: team ffa" do
+  test "cheeky_switcher: team ffa" do
     result =
       BalanceLib.create_balance(
         [
@@ -460,7 +461,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{6 => 9}
         ],
         3,
-        algorithm: :party_preserver
+        algorithm: :cheeky_switcher
       )
       |> Map.drop([:logs, :time_taken])
 
@@ -505,7 +506,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "team_preserver: two parties" do
+  @tag runnable: true
+  test "cheeky_switcher: MasterBel2 case" do
     result =
       BalanceLib.create_balance(
         [
@@ -530,7 +532,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{116 => 10.27}
         ],
         2,
-        algorithm: :party_preserver
+        algorithm: :cheeky_switcher
       )
 
     assert Map.drop(result, [:logs, :time_taken]) == %{
@@ -568,7 +570,69 @@ defmodule Teiserver.Battle.BalanceLibTest do
   end
 
   @tag runnable: true
-  test "team_preserver: bigger game group" do
+  test "loser_picks: MasterBel2 case" do
+    result =
+      BalanceLib.create_balance(
+        [
+          # Our high tier party
+          %{101 => 9.39, 102 => 15.14},
+
+          # Our other high tier party
+          %{103 => 28.84, 104 => 15.06},
+
+          # Other players, a range of ratings
+          %{105 => 43.69},
+          %{106 => 29.56},
+          %{107 => 28.27},
+          %{108 => 25.34},
+          %{109 => 23.45},
+          %{110 => 21.65},
+          %{111 => 21.6},
+          %{112 => 18.46},
+          %{113 => 17.7},
+          %{114 => 16.29},
+          %{115 => 16.01},
+          %{116 => 10.27}
+        ],
+        2,
+        algorithm: :cheeky_switcher
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 105, 2 => 106},
+             deviation: 2,
+             ratings: %{1 => 248, 2 => 253},
+             team_groups: %{
+               1 => [
+                 %{count: 2, group_rating: 24.53, members: [101, 102], ratings: [9.39, 15.14]},
+                 %{count: 1, group_rating: 43.69, members: [105], ratings: [43.69]},
+                 %{count: 1, group_rating: 29.56, members: [106], ratings: [29.56]},
+                 %{count: 1, group_rating: 28.27, members: [107], ratings: [28.27]},
+                 %{count: 1, group_rating: 25.34, members: [108], ratings: [25.34]},
+                 %{count: 1, group_rating: 23.45, members: [109], ratings: [23.45]},
+                 %{count: 1, group_rating: 10.27, members: [116], ratings: [10.27]}
+               ],
+               2 => [
+                 %{count: 2, group_rating: 43.9, members: [103, 104], ratings: [28.84, 15.06]},
+                 %{count: 1, group_rating: 21.65, members: [110], ratings: [21.65]},
+                 %{count: 1, group_rating: 21.6, members: [111], ratings: [21.6]},
+                 %{count: 1, group_rating: 18.46, members: [112], ratings: [18.46]},
+                 %{count: 1, group_rating: 17.7, members: [113], ratings: [17.7]},
+                 %{count: 1, group_rating: 16.29, members: [114], ratings: [16.29]},
+                 %{count: 1, group_rating: 16.01, members: [115], ratings: [16.01]}
+               ]
+             },
+             team_players: %{
+               1 => [104, 105, 106, 107, 110, 111, 114, 116],
+               2 => [101, 102, 103, 108, 109, 112, 113, 115]
+             },
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 31.0, 2 => 31.625},
+             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+           }
+  end
+
+  test "cheeky_switcher: bigger game group" do
     result =
       BalanceLib.create_balance(
         [
@@ -593,7 +657,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{116 => 8}
         ],
         2,
-        algorithm: :party_preserver,
+        algorithm: :cheeky_switcher,
         rating_lower_boundary: 5,
         rating_upper_boundary: 5,
         mean_diff_max: 5,
@@ -636,7 +700,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
   end
 
   # @tag runnable: true
-  test "team_preserver: smurf party" do
+  test "cheeky_switcher: smurf party" do
     result =
       BalanceLib.create_balance(
         [
@@ -659,7 +723,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{116 => 8}
         ],
         2,
-        algorithm: :party_preserver
+        algorithm: :cheeky_switcher
       )
 
     assert Map.drop(result, [:logs, :time_taken]) == %{
@@ -696,7 +760,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
   end
 
   # @tag runnable: true
-  test "team_preserver: stacked groups" do
+  test "cheeky_switcher: stacked groups" do
     result =
       BalanceLib.create_balance(
         [
@@ -711,7 +775,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{109 => 26},
         ],
         2,
-        algorithm: :party_preserver
+        algorithm: :cheeky_switcher
       )
 
     assert Map.drop(result, [:logs, :time_taken]) == %{

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -447,4 +447,249 @@ defmodule Teiserver.Battle.BalanceLibTest do
              stdevs: %{1 => 16.0312195418814, 2 => 15.074295174236173}
            }
   end
+
+  test "optimistic: team ffa" do
+    result =
+      BalanceLib.create_balance(
+        [
+          %{1 => 5},
+          %{2 => 6},
+          %{3 => 7},
+          %{4 => 8},
+          %{5 => 9},
+          %{6 => 9}
+        ],
+        3,
+        algorithm: :party_preserver,
+      )
+      |> Map.drop([:logs, :time_taken])
+
+    assert result == %{
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 9, members: [5], ratings: [9]},
+                 %{count: 1, group_rating: 6, members: [2], ratings: [6]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 9, members: [6], ratings: [9]},
+                 %{count: 1, group_rating: 5, members: [1], ratings: [5]}
+               ],
+               3 => [
+                 %{count: 1, group_rating: 8, members: [4], ratings: [8]},
+                 %{count: 1, group_rating: 7, members: [3], ratings: [7]}
+               ]
+             },
+             team_players: %{
+               1 => [5, 2],
+               2 => [6, 1],
+               3 => [4, 3]
+             },
+             ratings: %{
+               1 => 15,
+               2 => 14,
+               3 => 15
+             },
+             captains: %{
+               1 => 5,
+               2 => 6,
+               3 => 4
+             },
+             team_sizes: %{
+               1 => 2,
+               2 => 2,
+               3 => 2
+             },
+             deviation: 0,
+             means: %{1 => 7.5, 2 => 7.0, 3 => 7.5},
+             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5}
+           }
+  end
+
+  test "optimistic: two parties" do
+    result =
+      BalanceLib.create_balance(
+        [
+          # Our high tier party
+          %{101 => 9.39, 102 => 15.14},
+
+          # Our other high tier party
+          %{103 => 28.84, 104 => 15.06},
+
+          # Other players, a range of ratings
+          %{105 => 43.69},
+          %{106 => 29.56},
+          %{107 => 28.27},
+          %{108 => 25.34},
+          %{109 => 23.45},
+          %{110 => 21.65},
+          %{111 => 21.6},
+          %{112 => 18.46},
+          %{113 => 17.7},
+          %{114 => 16.29},
+          %{115 => 16.01},
+          %{116 => 10.27}
+        ],
+        2,
+        algorithm: :party_preserver
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 105, 2 => 106},
+             deviation: 2,
+             ratings: %{1 => 248, 2 => 253},
+             team_groups: %{
+               1 => [
+                 %{count: 2, group_rating: 24.53, members: [101, 102], ratings: [9.39, 15.14]},
+                 %{count: 1, group_rating: 43.69, members: [105], ratings: [43.69]},
+                 %{count: 1, group_rating: 29.56, members: [106], ratings: [29.56]},
+                 %{count: 1, group_rating: 28.27, members: [107], ratings: [28.27]},
+                 %{count: 1, group_rating: 25.34, members: [108], ratings: [25.34]},
+                 %{count: 1, group_rating: 23.45, members: [109], ratings: [23.45]},
+                 %{count: 1, group_rating: 10.27, members: [116], ratings: [10.27]}
+               ],
+               2 => [
+                 %{count: 2, group_rating: 43.9, members: [103, 104], ratings: [28.84, 15.06]},
+                 %{count: 1, group_rating: 21.65, members: [110], ratings: [21.65]},
+                 %{count: 1, group_rating: 21.6, members: [111], ratings: [21.6]},
+                 %{count: 1, group_rating: 18.46, members: [112], ratings: [18.46]},
+                 %{count: 1, group_rating: 17.7, members: [113], ratings: [17.7]},
+                 %{count: 1, group_rating: 16.29, members: [114], ratings: [16.29]},
+                 %{count: 1, group_rating: 16.01, members: [115], ratings: [16.01]}
+               ]
+             },
+             team_players: %{
+               1 => [104, 105, 106, 107, 110, 111, 114, 116],
+               2 => [101, 102, 103, 108, 109, 112, 113, 115]
+             },
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 31.0, 2 => 31.625},
+             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+           }
+  end
+
+  test "optimistic: bigger game group" do
+    result =
+      BalanceLib.create_balance(
+        [
+          # Two high tier players partied together
+          %{101 => 41, 102 => 35},
+
+          # A bunch of mid-low tier players together
+          %{103 => 20, 104 => 17, 105 => 13.5},
+
+          # A smaller bunch of even lower tier players
+          %{106 => 15, 107 => 7.5},
+
+          # Other players, a range of ratings
+          %{108 => 31},
+          %{109 => 26},
+          %{110 => 25},
+          %{111 => 21},
+          %{112 => 19},
+          %{113 => 16},
+          %{114 => 16},
+          %{115 => 14},
+          %{116 => 8}
+        ],
+        2,
+        algorithm: :party_preserver,
+        rating_lower_boundary: 5,
+        rating_upper_boundary: 5,
+        mean_diff_max: 5,
+        stddev_diff_max: 5
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 112, 2 => 103},
+             deviation: 2,
+             ratings: %{1 => 161, 2 => 164},
+             team_groups: %{
+               1 => [
+                 %{count: 3, group_rating: 51, members: [112, 113, 114], ratings: [19, 16, 16]},
+                 %{count: 2, group_rating: 22, members: [115, 116], ratings: [14, 8]},
+                 %{count: 1, group_rating: 41, members: [101], ratings: [41]},
+                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
+                 %{count: 1, group_rating: 21, members: [111], ratings: [21]}
+               ],
+               2 => [
+                 %{
+                   count: 3,
+                   group_rating: 50.5,
+                   members: [103, 104, 105],
+                   ratings: [20, 17, 13.5]
+                 },
+                 %{count: 2, group_rating: 22.5, members: [106, 107], ratings: [15, 7.5]},
+                 %{count: 1, group_rating: 35, members: [102], ratings: [35]},
+                 %{count: 1, group_rating: 31, members: [108], ratings: [31]},
+                 %{count: 1, group_rating: 25, members: [110], ratings: [25]}
+               ]
+             },
+             team_players: %{
+               1 => [112, 113, 114, 115, 116, 101, 109, 111],
+               2 => [103, 104, 105, 106, 107, 102, 108, 110]
+             },
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 20.125, 2 => 20.5},
+             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312}
+           }
+  end
+
+  test "optimistic: smurf party" do
+    result =
+      BalanceLib.create_balance(
+        [
+          # Our smurf party
+          %{101 => 51, 102 => 10, 103 => 10},
+
+          # Other players, a range of ratings
+          %{104 => 35},
+          %{105 => 34},
+          %{106 => 29},
+          %{107 => 28},
+          %{108 => 27},
+          %{109 => 26},
+          %{110 => 25},
+          %{111 => 21},
+          %{112 => 19},
+          %{113 => 16},
+          %{114 => 15},
+          %{115 => 14},
+          %{116 => 8}
+        ],
+        2,
+        algorithm: :party_preserver
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 101, 2 => 104},
+             deviation: 0,
+             ratings: %{1 => 184, 2 => 184},
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
+                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
+                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
+                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
+                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
+                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
+                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
+                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
+                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
+                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
+                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
+                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
+                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
+                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
+                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
+               ]
+             },
+             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 23.0, 2 => 23.0},
+             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+           }
+  end
 end

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -457,68 +457,6 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "cheeky_switcher: team ffa" do
-    result =
-      BalanceLib.create_balance(
-        [
-          %{1 => 5},
-          %{2 => 6},
-          %{3 => 7},
-          %{4 => 8},
-          %{5 => 9},
-          %{6 => 9}
-        ],
-        3,
-        algorithm: :cheeky_switcher
-      )
-      |> Map.drop([:logs, :time_taken, :team_groups, :team_players])
-
-    assert result == %{
-      captains: %{1 => 4, 2 => 2, 3 => 6},
-      deviation: 0,
-      means: %{1 => 7.5, 2 => 7.5, 3 => 7.0},
-      ratings: %{1 => 15, 2 => 15, 3 => 14},
-      stdevs: %{1 => 0.5, 2 => 1.5, 3 => 2.0},
-      team_sizes: %{1 => 2, 2 => 2, 3 => 2},
-      parties: {0, 0}
-    }
-  end
-
-  @tag runnable: false
-  test "cheeky_switcher: MasterBel2 case" do
-    result =
-      BalanceLib.create_balance(
-        [
-          %{:hitman => 9.39, :kayme => 15.14},
-          %{:eural => 28.84, :morgan => 15.06},
-          %{:zerpiderp => 43.69},
-          %{:gabb => 29.56},
-          %{:flaka => 28.27},
-          %{:gegx001 => 25.34},
-          %{:lordvenom1 => 23.45},
-          %{:notlobsters => 21.65},
-          %{:trimbil => 21.6},
-          %{:redspatula => 18.46},
-          %{:claaay => 17.7},
-          %{:korbal22 => 16.29},
-          %{:p4r0 => 16.01},
-          %{:amadeuz => 10.27}
-        ],
-        2,
-        algorithm: :cheeky_switcher
-      )
-
-    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
-             captains: %{1 => :hitman, 2 => :eural},
-              deviation: 0,
-              means: %{1 => 21.2825, 2 => 21.307499999999997},
-              ratings: %{1 => 170.26, 2 => 170.45999999999998},
-              stdevs: %{1 => 9.866508691021357, 2 => 6.440535206797646},
-              team_sizes: %{1 => 8, 2 => 8},
-              parties: {2, 2}
-           }
-  end
-
   @tag runnable: false
   test "loser_picks: MasterBel2 case" do
     result =
@@ -554,117 +492,6 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "cheeky_switcher: bigger game group" do
-    result =
-      BalanceLib.create_balance(
-        [
-          # Two high tier players partied together
-          %{101 => 41, 102 => 35},
-
-          # A bunch of mid-low tier players together
-          %{103 => 20, 104 => 17, 105 => 13.5},
-
-          # A smaller bunch of even lower tier players
-          %{106 => 15, 107 => 7.5},
-
-          # Other players, a range of ratings
-          %{108 => 31},
-          %{109 => 26},
-          %{110 => 25},
-          %{111 => 21},
-          %{112 => 19},
-          %{113 => 16},
-          %{114 => 16},
-          %{115 => 14},
-          %{116 => 8}
-        ],
-        2,
-        algorithm: :cheeky_switcher,
-        rating_lower_boundary: 5,
-        rating_upper_boundary: 5,
-        mean_diff_max: 5,
-        stddev_diff_max: 5
-      )
-
-    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
-             captains: %{1 => 103, 2 => 101},
-              deviation: 0,
-              means: %{1 => 20.3125, 2 => 20.3125},
-              ratings: %{1 => 162.5, 2 => 162.5},
-              stdevs: %{1 => 5.963102694906403, 2 => 11.227581830029118},
-              team_sizes: %{1 => 8, 2 => 8},
-              parties: {3, 3}
-           }
-  end
-
-  @tag runnable: false
-  test "cheeky_switcher: smurf party" do
-    result =
-      BalanceLib.create_balance(
-        [
-          # Our smurf party
-          %{101 => 51, 102 => 10, 103 => 10},
-
-          # Other players, a range of ratings
-          %{104 => 35},
-          %{105 => 34},
-          %{106 => 29},
-          %{107 => 28},
-          %{108 => 27},
-          %{109 => 26},
-          %{110 => 25},
-          %{111 => 21},
-          %{112 => 19},
-          %{113 => 16},
-          %{114 => 15},
-          %{115 => 14},
-          %{116 => 8}
-        ],
-        2,
-        algorithm: :cheeky_switcher
-      )
-
-    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
-             captains: %{1 => 101, 2 => 104},
-              deviation: 0,
-              means: %{1 => 23.0, 2 => 23.0},
-              ratings: %{1 => 184, 2 => 184},
-              stdevs: %{1 => 13.238202294873727, 2 => 8.0156097709407},
-              team_sizes: %{1 => 8, 2 => 8},
-              parties: {1, 1}
-           }
-  end
-
-  @tag runnable: false
-  test "cheeky_switcher: stacked groups" do
-    result =
-      BalanceLib.create_balance(
-        [
-          %{101 => 11, 102 => 10, 103 => 10, 104 => 35},
-          %{110 => 25, 111 => 21, 112 => 19, 113 => 16},
-          %{114 => 15, 115 => 14, 116 => 8},
-
-          %{105 => 34},
-          %{106 => 29},
-          %{107 => 28},
-          %{108 => 27},
-          %{109 => 26},
-        ],
-        2,
-        algorithm: :cheeky_switcher
-      )
-
-    assert Map.drop(result, [:logs, :time_taken, :team_groups, :team_players]) == %{
-             captains: %{1 => 110, 2 => 114},
-              deviation: 1,
-              means: %{1 => 20.625, 2 => 20.375},
-              ratings: %{1 => 165, 2 => 163},
-              stdevs: %{1 => 7.8888766627448295, 2 => 9.205127647132331},
-              team_sizes: %{1 => 8, 2 => 8},
-              parties: {2, 3}
-           }
-  end
-
   @tag runnable: false
   test "loser_picks: stacked groups" do
     result =
@@ -696,72 +523,255 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  @tag runnable: false
-  test "Compare algorithms stacked groups" do
-    groups = [ [11, 10, 10, 35], [25, 21, 19, 16], [15, 14, 8],
-      [34], [29], [28], [27], [26], ]
-    compare_algorithm_results(groups, 2, "stacked groups")
-    compare_algorithm_times(groups, 2, "stacked groups")
-  end
+  @stacked_groups %{
+    groups: [ [11, 10, 10, 35], [25, 21, 19, 16], [15, 14, 8],
+      [34], [29], [28], [27], [26], ],
+    name: "Stacked groups",
+    team_count: 2
+  }
 
-  @tag runnable: false
-  test "Compare algorithms MasterBel2 case" do
-    groups = [ [9.39, 15.14], [28.84, 15.06], [43.69], [29.56], [28.27],
+  @master_bel %{
+    groups: [ [9.39, 15.14], [28.84, 15.06], [43.69], [29.56], [28.27],
       [25.34], [23.45], [21.65], [21.6], [18.46], [17.7], [16.29],
-      [16.01], [10.27] ]
-    compare_algorithm_results(groups, 2, "MasterBel2 case")
-    compare_algorithm_times(groups, 2, "MasterBel2 case")
-  end
+      [16.01], [10.27] ],
+    name: "MasterBel2 case",
+    team_count: 2
+  }
 
-  @tag runnable: false
-  test "Compare algorithms: team_ffa" do
-    groups = [ [5], [6], [7], [8], [9], [9] ]
-    compare_algorithm_results(groups, 3, "team_ffa")
-    compare_algorithm_times(groups, 3, "team_ffa")
-  end
+  @team_ffa %{
+    groups: [ [9.39, 15.14], [28.84, 15.06], [43.69], [29.56], [28.27],
+      [25.34], [23.45], [21.65], [21.6], [18.46], [17.7], [16.29],
+      [16.01], [10.27] ],
+    name: "Team FFA",
+    team_count: 3
+  }
 
-  @tag runnable: false
-  test "Compare algorithms: smurf party" do
-    groups = [ [51, 10, 10],
+  @smurf_party %{
+    groups: [ [51, 10, 10],
       [35], [34], [29], [28], [27], [26], [25], [21], [19], [16],
-      [15], [14], [8] ]
-    compare_algorithm_results(groups, 2, "smurf party")
-    compare_algorithm_times(groups, 2, "smurf party")
-  end
+      [15], [14], [8] ],
+    name: "Smurf party",
+    team_count: 2
+  }
 
-  @tag runnable: false
-  test "Compare algorithms: odd users" do
-    groups = [ [51], [10], [10], [35], [34], [29], [28], [27], [26],
-      [25], [21], [19], [16], [15], [8] ]
-    compare_algorithm_results(groups, 2, "odd users")
-    compare_algorithm_times(groups, 2, "odd users")
-  end
+  @odd_users %{
+    groups: [ [51, 10, 10],
+      [35], [34], [29], [28], [27], [26], [25], [21], [19], [16],
+      [15], [14], [8] ],
+    name: "Odd users",
+    team_count: 2
+  }
+
+  @even_spread %{
+    groups: [ [24.42], [23.11], [22.72], [21.01], [20.13], [20.81], [19.78],
+      [18.20], [17.10], [16.11], [15.10], [14.08], [13.91], [13.19], [12.1],
+      [11.01], ],
+    name: "Even spread",
+    team_count: 2
+  }
+
+  @even_spread_integers %{
+    groups: [ [24, 23, 22, 21, 20, 20, 19, 18, 17, 16, 15, 14, 13, 13, 12, 11] ],
+    name: "Even spread integers",
+    team_count: 2
+  }
+
+  @high_low %{
+    groups:  [
+      [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
+      [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], ],
+    name: "High low",
+    team_count: 2
+  }
+
+  @big_lobboy %{
+    groups:  [
+      [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
+      [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], [23.1], [13.1], [24.1], [23.1],
+      [13.2], [25.1], [13.2], [2.1, 43.1], [20.1], [19.1], [23.01, 4.1, 23.01, 13.1], [25.1],
+      [43.9], [22.1], [14.0], [2.2], [33.1], [13.9], [14.29, 23.7],
+      ],
+    name: "Big lobby (40)",
+    team_count: 2
+  }
+
+  @mega_lobby %{
+    groups:  [
+      [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
+      [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], [23.1], [13.1], [24.1], [23.1],
+      [13.2], [25.1], [13.2], [2.1], [43.1], [20.1], [19.1], [23.01], [4.1], [23.01], [13.1], [25.1],
+      [43.9], [22.1], [14.0], [2.2], [33.1], [13.9], [14.29], [23.7], [2.1], [23.12], [23.19], [23.1],
+      [40.9], [21.1], [15.2], [2.8], [33.2], [3.1], [15.2], [23.7], [1.1], [23.21], [33.1], [22.1],
+      [41.9], [20], [18], [2.9], [33.9], [33.1], [15.1], [23.8], [2.1], [23.41], [43.1], [21.1],
+      [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18],
+      ],
+    name: "Mega lobby (80)",
+    team_count: 2
+  }
+
+  @mega_lobby_parties %{
+    groups:  [
+      [54.42, 43.11], [42.72], [41.01], [30.13, 30.81, 9.78], [8.20],
+      [7.10], [6.11], [5.10], [4.08, 3.91, 39.19], [2.1], [1.01], [23.1], [13.1], [24.1, 23.1],
+      [13.2, 25.1], [13.2], [2.1], [43.1], [20.1, 19.1, 23.01, 4.1], [23.01], [13.1], [25.1],
+      [43.9], [22.1, 14.0, 2.2, 33.1, 13.9], [14.29], [23.7, 2.1], [23.12], [23.19], [23.1],
+      [40.9], [21.1, 15.2, 2.8], [33.2], [3.1], [15.2, 23.7, 1.1, 23.21, 33.1], [22.1],
+      [41.9], [20], [18], [2.9], [33.9], [33.1], [15.1], [23.8, 2.1, 23.41, 43.1], [21.1],
+      [7, 8, 9, 10], [11, 12, 13, 14, 15, 16, 17, 18],
+    ],
+    name: "Mega lobby, many parties (80)",
+    team_count: 2
+  }
+
+  # @iterations 1000
+  @iterations 100
 
   @tag runnable: true
-  test "Compare algorithms: Even spread" do
-    groups = [ [24.42], [23.11], [22.72], [21.01], [20.13], [20.81], [19.78],
-      [18.20], [17.10], [16.11], [15.10], [14.08], [13.91], [13.19], [12.1],
-      [11.01], ]
-    compare_algorithm_results(groups, 2, "Even spread")
-    compare_algorithm_times(groups, 2, "Even spread")
+  @tag timeout: :infinity
+  test "Compare all algorithms against cases" do
+    cases = [@stacked_groups, @master_bel, @team_ffa, @smurf_party, @odd_users, @even_spread, @even_spread_integers, @high_low, @mega_lobby, @mega_lobby_parties]
+    algorithms = [:cheeky_switcher, :loser_picks, :cheeky_switcher_rating, :cheeky_switcher_smart]
+    # cases = [@stacked_groups]
+    # algorithms = [:cheeky_switcher_smart]
+
+    results = summarize_average_case_results_per_algorithm(algorithms, cases)
+
+    IO.inspect(results, label: "Results", charlists: :as_lists)
   end
 
-  @tag runnable: false
-  test "Compare algorithms: Even spread - itegers" do
-    groups = [ [24], [23], [22], [21], [20], [20], [19], [18], [17], [16],
-     [15], [14], [13], [13], [12], [11] ]
-    compare_algorithm_results(groups, 2, "Even spread - integers")
-    compare_algorithm_times(groups, 2, "Even spread - integers")
+  def summarize_average_case_results_per_algorithm(algorithms, cases) do
+    Enum.map(algorithms, fn algorithm ->
+      results = Enum.map(cases, fn case_data ->
+        res = run_balance_algorithm(case_data, algorithm)
+        IO.inspect(res, label: "Result for #{case_data[:name]} with #{algorithm}", charlists: :as_lists)
+        res
+      end)
+
+      {algorithm, summarize_results(results)}
+    end)
   end
 
-  @tag runnable: false
-  test "Compare algorithms: High low" do
-    groups = [
-      [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
-      [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], ]
-    compare_algorithm_results(groups, 2, "High low")
-    compare_algorithm_times(groups, 2, "High low")
+  def summarize_results(results) do
+    result_count = length(results)
+    Enum.reduce(results, %{
+      average_deviation: 0,
+      average_time: 0,
+      parties_preserved: 0,
+    }, fn result, acc ->
+      %{
+        average_deviation: acc.average_deviation + result.deviation / result_count,
+        average_time: acc.average_time + result.average_time / result_count,
+        parties_preserved: acc.parties_preserved + result.parties[:preserved],
+      }
+    end)
   end
+
+  def run_balance_algorithm(case_data, algorithm) do
+    parties = case_data[:groups]
+    team_count = case_data[:team_count]
+    case_name = case_data[:name]
+
+    party_map_list = to_party_map_list(parties)
+
+    balancing_result =
+      BalanceLib.create_balance(
+        party_map_list,
+        team_count,
+        algorithm: algorithm
+      )
+
+    result_time = if @iterations > 0 do
+      1..@iterations
+        |> Enum.map(fn _ ->
+          BalanceLib.create_balance(
+            party_map_list,
+            team_count,
+            algorithm: algorithm
+          )
+        end)
+        |> Enum.map(fn result -> result.time_taken end)
+        |> Enum.sum()
+    else
+      0
+    end
+
+    %{
+      deviation: balancing_result.deviation,
+      ratings: balancing_result.ratings,
+      means: balancing_result.means,
+      stdevs: balancing_result.stdevs,
+      time_taken: balancing_result.time_taken,
+      team_groups: simple_teams(balancing_result.team_groups),
+      parties: parties_preserved(parties, simple_teams(balancing_result.team_groups)),
+      average_time: if @iterations > 0 do result_time / @iterations else 0 end,
+    }
+  end
+
+  # @tag runnable: false
+  # test "Compare algorithms stacked groups" do
+  #   compare_algorithm_results(stacked_groups["groups"], stacked_groups["team_count"], stacked_groups["name"])
+  #   compare_algorithm_times(stacked_groups["groups"], stacked_groups["team_count"], stacked_groups["name"])
+  # end
+
+
+  # @tag runnable: false
+  # test "Compare algorithms MasterBel2 case" do
+  #   groups = [ [9.39, 15.14], [28.84, 15.06], [43.69], [29.56], [28.27],
+  #     [25.34], [23.45], [21.65], [21.6], [18.46], [17.7], [16.29],
+  #     [16.01], [10.27] ]
+  #   compare_algorithm_results(groups, 2, "MasterBel2 case")
+  #   compare_algorithm_times(groups, 2, "MasterBel2 case")
+  # end
+
+  # @tag runnable: false
+  # test "Compare algorithms: team_ffa" do
+  #   groups = [ [5], [6], [7], [8], [9], [9] ]
+  #   compare_algorithm_results(groups, 3, "team_ffa")
+  #   compare_algorithm_times(groups, 3, "team_ffa")
+  # end
+
+  # @tag runnable: false
+  # test "Compare algorithms: smurf party" do
+  #   groups = [ [51, 10, 10],
+  #     [35], [34], [29], [28], [27], [26], [25], [21], [19], [16],
+  #     [15], [14], [8] ]
+  #   compare_algorithm_results(groups, 2, "smurf party")
+  #   compare_algorithm_times(groups, 2, "smurf party")
+  # end
+
+  # @tag runnable: false
+  # test "Compare algorithms: odd users" do
+  #   groups = [ [51], [10], [10], [35], [34], [29], [28], [27], [26],
+  #     [25], [21], [19], [16], [15], [8] ]
+  #   compare_algorithm_results(groups, 2, "odd users")
+  #   compare_algorithm_times(groups, 2, "odd users")
+  # end
+
+  # @tag runnable: true
+  # test "Compare algorithms: Even spread" do
+  #   groups = [ [24.42], [23.11], [22.72], [21.01], [20.13], [20.81], [19.78],
+  #     [18.20], [17.10], [16.11], [15.10], [14.08], [13.91], [13.19], [12.1],
+  #     [11.01], ]
+  #   compare_algorithm_results(groups, 2, "Even spread")
+  #   compare_algorithm_times(groups, 2, "Even spread")
+  # end
+
+  # @tag runnable: false
+  # test "Compare algorithms: Even spread - itegers" do
+  #   groups = [ [24], [23], [22], [21], [20], [20], [19], [18], [17], [16],
+  #    [15], [14], [13], [13], [12], [11] ]
+  #   compare_algorithm_results(groups, 2, "Even spread - integers")
+  #   compare_algorithm_times(groups, 2, "Even spread - integers")
+  # end
+
+  # @tag runnable: false
+  # test "Compare algorithms: High low" do
+  #   groups = [
+  #     [54.42], [43.11], [42.72], [41.01], [30.13], [30.81], [9.78], [8.20],
+  #     [7.10], [6.11], [5.10], [4.08], [3.91], [3.19], [2.1], [1.01], ]
+  #   compare_algorithm_results(groups, 2, "High low")
+  #   compare_algorithm_times(groups, 2, "High low")
+  # end
 
   def simple_teams(teams) do
     teams
@@ -856,6 +866,13 @@ defmodule Teiserver.Battle.BalanceLibTest do
       party_map_list,
       parties,
       team_count,
+      :cheeky_switcher_smart,
+      test_name)
+
+    run_algorithm_and_print_results(
+      party_map_list,
+      parties,
+      team_count,
       :loser_picks,
       test_name)
 
@@ -904,10 +921,22 @@ defmodule Teiserver.Battle.BalanceLibTest do
       |> Enum.map(fn result -> result.time_taken end)
       |> Enum.sum()
 
+    result_cheeky_switcher_smart_time = 1..iterations
+      |> Enum.map(fn _ ->
+        BalanceLib.create_balance(
+          party_map_list,
+          team_count,
+          algorithm: :cheeky_switcher_smart
+        )
+      end)
+      |> Enum.map(fn result -> result.time_taken end)
+      |> Enum.sum()
+
     IO.inspect(%{
       loser_picks_time: result_loser_picks_time / iterations,
       cheeky_switcher_time: result_cheeky_switcher_time / iterations,
-      cheeky_switcher_rating_time: result_cheeky_switcher_rating_time / iterations
+      cheeky_switcher_rating_time: result_cheeky_switcher_rating_time / iterations,
+      cheeky_switcher_smart_time: result_cheeky_switcher_smart_time / iterations
     })
   end
 end

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -448,7 +448,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "optimistic: team ffa" do
+  test "team_preserver: team ffa" do
     result =
       BalanceLib.create_balance(
         [
@@ -460,7 +460,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
           %{6 => 9}
         ],
         3,
-        algorithm: :party_preserver,
+        algorithm: :party_preserver
       )
       |> Map.drop([:logs, :time_taken])
 
@@ -505,7 +505,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "optimistic: two parties" do
+  test "team_preserver: two parties" do
     result =
       BalanceLib.create_balance(
         [
@@ -567,7 +567,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "optimistic: bigger game group" do
+  @tag runnable: true
+  test "team_preserver: bigger game group" do
     result =
       BalanceLib.create_balance(
         [
@@ -634,7 +635,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  test "optimistic: smurf party" do
+  # @tag runnable: true
+  test "team_preserver: smurf party" do
     result =
       BalanceLib.create_balance(
         [
@@ -658,6 +660,110 @@ defmodule Teiserver.Battle.BalanceLibTest do
         ],
         2,
         algorithm: :party_preserver
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 101, 2 => 104},
+             deviation: 0,
+             ratings: %{1 => 184, 2 => 184},
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
+                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
+                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
+                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
+                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
+                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
+                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
+                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
+                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
+                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
+                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
+                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
+                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
+                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
+                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
+               ]
+             },
+             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 23.0, 2 => 23.0},
+             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+           }
+  end
+
+  # @tag runnable: true
+  test "team_preserver: stacked groups" do
+    result =
+      BalanceLib.create_balance(
+        [
+          %{101 => 11, 102 => 10, 103 => 10, 104 => 35},
+          %{110 => 25, 111 => 21, 112 => 19, 113 => 16},
+          %{114 => 15, 115 => 14, 116 => 8},
+
+          %{105 => 34},
+          %{106 => 29},
+          %{107 => 28},
+          %{108 => 27},
+          %{109 => 26},
+        ],
+        2,
+        algorithm: :party_preserver
+      )
+
+    assert Map.drop(result, [:logs, :time_taken]) == %{
+             captains: %{1 => 101, 2 => 104},
+             deviation: 0,
+             ratings: %{1 => 184, 2 => 184},
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 51, members: [101], ratings: [51]},
+                 %{count: 1, group_rating: 29, members: [106], ratings: [29]},
+                 %{count: 1, group_rating: 27, members: [108], ratings: [27]},
+                 %{count: 1, group_rating: 25, members: [110], ratings: [25]},
+                 %{count: 1, group_rating: 19, members: [112], ratings: [19]},
+                 %{count: 1, group_rating: 15, members: [114], ratings: [15]},
+                 %{count: 1, group_rating: 10, members: [102], ratings: [10]},
+                 %{count: 1, group_rating: 8, members: [116], ratings: [8]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 35, members: [104], ratings: '#'},
+                 %{count: 1, group_rating: 34, members: [105], ratings: [34]},
+                 %{count: 1, group_rating: 28, members: [107], ratings: [28]},
+                 %{count: 1, group_rating: 26, members: [109], ratings: [26]},
+                 %{count: 1, group_rating: 21, members: [111], ratings: [21]},
+                 %{count: 1, group_rating: 16, members: [113], ratings: [16]},
+                 %{count: 1, group_rating: 14, members: [115], ratings: [14]},
+                 %{count: 1, group_rating: 10, members: [103], ratings: '\n'}
+               ]
+             },
+             team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
+             team_sizes: %{1 => 8, 2 => 8},
+             means: %{1 => 23.0, 2 => 23.0},
+             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+           }
+  end
+
+  # @tag runnable: true
+  test "loser_picks: stacked groups" do
+    result =
+      BalanceLib.create_balance(
+        [
+          %{101 => 11, 102 => 10, 103 => 10, 104 => 35},
+          %{110 => 25, 111 => 21, 112 => 19, 113 => 16},
+          %{114 => 15, 115 => 14, 116 => 8},
+
+          %{105 => 34},
+          %{106 => 29},
+          %{107 => 28},
+          %{108 => 27},
+          %{109 => 26},
+        ],
+        2,
+        algorithm: :loser_picks
       )
 
     assert Map.drop(result, [:logs, :time_taken]) == %{

--- a/test/balance_lib_test.exs
+++ b/test/balance_lib_test.exs
@@ -511,25 +511,20 @@ defmodule Teiserver.Battle.BalanceLibTest do
     result =
       BalanceLib.create_balance(
         [
-          # Our high tier party
-          %{101 => 9.39, 102 => 15.14},
-
-          # Our other high tier party
-          %{103 => 28.84, 104 => 15.06},
-
-          # Other players, a range of ratings
-          %{105 => 43.69},
-          %{106 => 29.56},
-          %{107 => 28.27},
-          %{108 => 25.34},
-          %{109 => 23.45},
-          %{110 => 21.65},
-          %{111 => 21.6},
-          %{112 => 18.46},
-          %{113 => 17.7},
-          %{114 => 16.29},
-          %{115 => 16.01},
-          %{116 => 10.27}
+          %{:hitman => 9.39, :kayme => 15.14},
+          %{:eural => 28.84, :morgan => 15.06},
+          %{:zerpiderp => 43.69},
+          %{:gabb => 29.56},
+          %{:flaka => 28.27},
+          %{:gegx001 => 25.34},
+          %{:lordvenom1 => 23.45},
+          %{:notlobsters => 21.65},
+          %{:trimbil => 21.6},
+          %{:redspatula => 18.46},
+          %{:claaay => 17.7},
+          %{:korbal22 => 16.29},
+          %{:p4r0 => 16.01},
+          %{:amadeuz => 10.27}
         ],
         2,
         algorithm: :cheeky_switcher
@@ -569,30 +564,25 @@ defmodule Teiserver.Battle.BalanceLibTest do
            }
   end
 
-  @tag runnable: true
+  # @tag runnable: true
   test "loser_picks: MasterBel2 case" do
     result =
       BalanceLib.create_balance(
         [
-          # Our high tier party
-          %{101 => 9.39, 102 => 15.14},
-
-          # Our other high tier party
-          %{103 => 28.84, 104 => 15.06},
-
-          # Other players, a range of ratings
-          %{105 => 43.69},
-          %{106 => 29.56},
-          %{107 => 28.27},
-          %{108 => 25.34},
-          %{109 => 23.45},
-          %{110 => 21.65},
-          %{111 => 21.6},
-          %{112 => 18.46},
-          %{113 => 17.7},
-          %{114 => 16.29},
-          %{115 => 16.01},
-          %{116 => 10.27}
+          %{:hitman => 9.39, :kayme => 15.14},
+          %{:eural => 28.84, :morgan => 15.06},
+          %{:zerpiderp => 43.69},
+          %{:gabb => 29.56},
+          %{:flaka => 28.27},
+          %{:gegx001 => 25.34},
+          %{:lordvenom1 => 23.45},
+          %{:notlobsters => 21.65},
+          %{:trimbil => 21.6},
+          %{:redspatula => 18.46},
+          %{:claaay => 17.7},
+          %{:korbal22 => 16.29},
+          %{:p4r0 => 16.01},
+          %{:amadeuz => 10.27}
         ],
         2,
         algorithm: :loser_picks
@@ -637,25 +627,20 @@ defmodule Teiserver.Battle.BalanceLibTest do
     result =
       BalanceLib.create_balance(
         [
-          # Our high tier party
-          %{101 => 9.39, 102 => 15.14},
-
-          # Our other high tier party
-          %{103 => 28.84, 104 => 15.06},
-
-          # Other players, a range of ratings
-          %{105 => 43.69},
-          %{106 => 29.56},
-          %{107 => 28.27},
-          %{108 => 25.34},
-          %{109 => 23.45},
-          %{110 => 21.65},
-          %{111 => 21.6},
-          %{112 => 18.46},
-          %{113 => 17.7},
-          %{114 => 16.29},
-          %{115 => 16.01},
-          %{116 => 10.27}
+          %{:hitman => 9.39, :kayme => 15.14},
+          %{:eural => 28.84, :morgan => 15.06},
+          %{:zerpiderp => 43.69},
+          %{:gabb => 29.56},
+          %{:flaka => 28.27},
+          %{:gegx001 => 25.34},
+          %{:lordvenom1 => 23.45},
+          %{:notlobsters => 21.65},
+          %{:trimbil => 21.6},
+          %{:redspatula => 18.46},
+          %{:claaay => 17.7},
+          %{:korbal22 => 16.29},
+          %{:p4r0 => 16.01},
+          %{:amadeuz => 10.27}
         ],
         2,
         algorithm: :brute_force
@@ -947,7 +932,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
       party
       |> Enum.with_index()
       |> Enum.map(fn {rating, member_index} ->
-        {index * 100 + member_index, rating}
+        {index * 10 + member_index, rating}
       end)
       |> Map.new()
     end)
@@ -982,7 +967,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
       stdevs: result_loser_picks.stdevs,
       time_taken: result_loser_picks.time_taken,
       team_groups: simple_teams(result_loser_picks.team_groups),
-      team_groups_full: result_loser_picks.team_groups
+      # team_groups_full: result_loser_picks.team_groups,
+      # logs: result_loser_picks.logs
     }, label: "#{test_name}: loser_picks", charlists: :as_lists)
 
     IO.inspect(%{
@@ -992,7 +978,8 @@ defmodule Teiserver.Battle.BalanceLibTest do
       stdevs: result_cheeky_switcher.stdevs,
       time_taken: result_cheeky_switcher.time_taken,
       team_groups: simple_teams(result_cheeky_switcher.team_groups),
-      team_groups_full: result_cheeky_switcher.team_groups
+      # team_groups_full: result_cheeky_switcher.team_groups,
+      # logs: result_cheeky_switcher.logs,
     }, label: "#{test_name}: cheeky_switcher", charlists: :as_lists)
 
     IO.inspect(%{
@@ -1010,7 +997,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
     assert result_cheeky_switcher.time_taken <= result_brute_force.time_taken
   end
 
-  # @tag runnable: true
+  @tag runnable: true
   test "Compare algorithms stacked groups" do
     parties = [
       [11, 10, 10, 35],
@@ -1025,7 +1012,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
     compare_algorithms(parties, 2, "stacked groups")
   end
 
-  # @tag runnable: true
+  @tag runnable: true
   test "Compare algorithms MasterBel2 case" do
     parties = [
       [9.39, 15.14],
@@ -1059,7 +1046,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
     compare_algorithms(parties, 3, "team_ffa")
   end
 
-  # @tag runnable: true
+  @tag runnable: true
   test "Compare algorithms: smurf party" do
     parties = [
        # Our smurf party


### PR DESCRIPTION
Hey there. I was reading the teiserver chat and saw a case of the balancing algorithm "failing" to preserve a party when there was a seemingly valid solution to the sorting.
![image](https://github.com/beyond-all-reason/balance_algorithm/assets/1506286/faeb936a-9bce-40ff-b843-3669fd58ca3e)
![image](https://github.com/beyond-all-reason/balance_algorithm/assets/1506286/c99d797a-aaea-44ff-b910-c1e8737c2f3f)


I have been a little annoyed at this myself, when trying to play with new friends from the discord and it feels like 50% of the time we end up on different teams anyway. It feels like even with a smurf party of [40, 12] players, it should be possible to solve in many cases.

So I thought I should at last have a go at it for fun. Maybe by exploring it we can find some area of improvement. I assume there have been several approaches tried already, and likely many aspects of what I propose have already been done and discarded, but in case not, here it is.

I don't really know the criteria of success in an algorithm, beyond equal total rating and number of members. It looks like the existing one also optimizes for standard deviation and mean, which mine currently does not do.

I had to move the original algorithm out of the main lib file, otherwise it would be gigantic, so I separated it into its own file, so there is a module per algorithm.

I moved the types and utility functions into its own file as well so they can be shared between the algorithms. Not sure if this is the best approach, same with the naming. I'm not completely in the loop of the best practices here.

**The algorithm is very much in the draft stages**, not having been tested against many scenarios, but not doing too bad at the ones I throw at it. It also lacks the full testing suite and documentation and has IO.inspect everywhere. The existing tests still pass for the loser_picks algorithm, while the newer tests fail (have not set up the exact success cases I would expect, just copy pasted)

My thinking is that if the algorithm can produce some viable, party-preserving solutions for some cases at least, that would be good. If the result of a given balancing case is not optimal, it can always fall back on the loser_picks algo. 

The runtime for very big lobbies can be potentially bad for the group-switching step, but I don't think it will be much of an issue when the number of players is only in the 16-player range.

Current algorithm:
1. Rough placement of rating-sorted groups into the different teams, starting with the highest group, and placing the next group in the team with the fewest players.
- This should be improved somewhat, as we might want to place the teams first, then the solo players.
2. If the teams are uneven, split up the biggest party, and repeat 1
- Maybe consider splitting up the party with the biggest internal rating difference, or the biggest total rating party, instead of the biggest party in terms of members straight away. This step is mostly for the smaller lobbies, or lobbies with many / big parties
3. We now have roughly even teams of members. Find the total rating difference between the two teams, and switch out a combination of groups (with equal number of players) that has a difference between them closest to half the rating difference. Brute force style :sunglasses: 
4. If the teams have become acceptably even, finish, otherwise break up the biggest party and repeat until there are no more parties.

This plays out more closely to what I would do with my human eye, trying to find a clever switch of groups to get the optimal minimum rating difference. Hardly an academic approach, but it works to an extent as far as I can tell, solving the mentioned grouping issue above, likely at the cost of standard deviations.

It could be fun to test out multiple sets of approaches in step 1, 2 and 3 for comparison. It might even be good to have a suite of algorithms that run, compare their stats and go with the best result for a given balance case, and get the both of all approaches.

Todos:
- Explore ordering alternatives in the 4 steps
- Benchmark against the original algorithm in a larger set of tests, comparing rating diff, stdev, possibly speed
- Add better log lines with user names
- Clean up the mess
- Test with 4 teams
- Make faster

Happy for any comments, and sorry for moving a lot of stuff around :sweat_smile: 